### PR TITLE
Re-order breakpoints due to cascading.

### DIFF
--- a/bitters/_grid_settings.scss
+++ b/bitters/_grid_settings.scss
@@ -7,6 +7,6 @@ $grid-columns: 12;
 $max-width: em(1088);
 
 // Define your breakpoints
-$mobile: new-breakpoint(max-width 480px 4);
-$tablet: new-breakpoint(max-width 768px 8);
 $desktop: new-breakpoint(min-width 769px 12);
+$tablet: new-breakpoint(max-width 768px 8);
+$mobile: new-breakpoint(max-width 480px 4);


### PR DESCRIPTION
Because these generate rules for the visual grid, they need to be defined in this order so they cascade correctly. Without this, when on a mobile-sized screen, you'd see 8 visual columns, even though there were only 4 being used.
