### PR TITLE
Don't use $form-font-size before it has been declared

### DIFF
--- a/base/_extends.scss
+++ b/base/_extends.scss
@@ -1,4 +1,4 @@
 %button {
   @include button(simple, $base-accent-color);
-  font-size: $form-font-size;
+  font-size: $base-font-size;
 }


### PR DESCRIPTION
I was getting an error `base/extends:3: error: unbound variable $form-font-size` (using grunt-sass).
This works around that.
