### PR TITLE
Switch order in base file to compile variables properly

### DIFF
--- a/base/_base.scss
+++ b/base/_base.scss
@@ -1,7 +1,7 @@
 @import "variables";
-@import "extends";
 @import "typography";
 @import "forms";
 @import "tables";
 @import "lists";
 @import "flashes";
+@import "extends";


### PR DESCRIPTION
I tried to run this in my Middleman app but came across compiling errors with a custom variable undefined in the "extends" file.
