### PR TITLE
Add Rails Engine and rake install task

### DIFF
--- a/lib/bitters.rb
+++ b/lib/bitters.rb
@@ -1,6 +1,21 @@
+require "bitters/engine"
 require "bitters/version"
 require "bitters/generator"
 
 module Bitters
-  # Your code goes here...
+  if defined?(Rails) && defined?(Rails::Engine)
+    class Engine < ::Rails::Engine
+      require 'bitters/engine'
+    end
+
+    module Rails
+      class Railtie < ::Rails::Railtie
+        rake_tasks do
+          load "tasks/install.rake"
+        end
+      end
+    end
+  else
+    Sass.load_paths << File.expand_path("../../app/assets/stylesheets", __FILE__)
+  end
 end

--- a/lib/bitters/engine.rb
+++ b/lib/bitters/engine.rb
@@ -1,0 +1,5 @@
+module Bitters
+  class Engine < Rails::Engine
+    # auto wire
+  end
+end

--- a/lib/tasks/install.rake
+++ b/lib/tasks/install.rake
@@ -1,0 +1,18 @@
+require 'fileutils'
+require 'find'
+
+namespace :bitters do
+  desc "Copy Bitters' files to the Rails assets directory."
+  task :install, [:sass_path] do |t, args|
+    args.with_defaults(:sass_path => 'public/stylesheets/sass')
+    source_root = File.expand_path(File.join(File.dirname(__FILE__), '..', '..'))
+    FileUtils.mkdir_p("#{Rails.root}/#{args.sass_path}/bitters")
+    FileUtils.cp_r("#{source_root}/app/assets/stylesheets/.", "#{Rails.root}/#{args.sass_path}/bitters", { :preserve => true })
+    Find.find("#{Rails.root}/#{args.sass_path}/bitters") do |path|
+      if path.end_with?(".css.scss")
+        path_without_css_extension = path.gsub(/\.css/.scss$/, ".scss")
+        FileUtils.mv(path, path_without_css_extension)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This follows the same conventions as Bourbon and Neat so Rails users can easily us Bitters just by adding `@import "bitters":` to their `application.css.scss`
