### PR TITLE
Set width on input type="file"

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -69,6 +69,10 @@ input[type="checkbox"], input[type="radio"] {
   margin-right: $base-line-height / 4;
 }
 
+input[type="file"] {
+  width: 100%;
+}
+
 select {
   width: auto;
   margin-bottom: $base-line-height;


### PR DESCRIPTION
Lack of width value on input[type="file"] caused scrollbars on any screen less than 400 pixels wide.
