### PR TITLE
Remove resize attribute from inputs.

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -48,7 +48,6 @@ select[multiple=multiple] {
   font-size: $form-font-size;
   margin-bottom: $base-line-height / 2;
   padding: ($base-line-height / 3) ($base-line-height / 3);
-  resize: vertical;
   width: 100%;
 
   &:hover {
@@ -60,6 +59,10 @@ select[multiple=multiple] {
     box-shadow: $form-box-shadow-focus;
     outline: none;
   }
+}
+
+textarea {
+  resize: vertical;
 }
 
 input[type="search"] {


### PR DESCRIPTION
This commit removes the CSS resize attribute declaration from input fields and applies it only to text areas. Fixes #33.
