### PR TITLE
Fixed typo in Refills link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,7 +21,7 @@
         <li><a href="http://bourbon.io" class="bourbon">Bourbon</a></li>
         <li><a href="http://neat.bourbon.io" class="neat">Neat</a></li>
         <li><a href="http://bitters.bourbon.io" class="bitters current">Bitters</a></li>
-        <li><a href="http://refills.bourbo.io" class="refills">Refills</a></li>
+        <li><a href="http://refills.bourbon.io" class="refills">Refills</a></li>
       </ul>
       <h1>All maintained by the design team at <a href="http://thoughtbot.com">thoughtbot</a></h1>
     </nav>


### PR DESCRIPTION
Just missing the 'n'.
