### PR TITLE
Include flash styling for flash alerts

### DIFF
--- a/app/assets/stylesheets/_flashes.scss
+++ b/app/assets/stylesheets/_flashes.scss
@@ -1,3 +1,7 @@
+%flash-alert {
+  @include flash($alert-color);
+}
+
 %flash-error {
   @include flash($error-color);
 }

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -41,6 +41,7 @@ $hover-button-color: $hover-link-color;
 $base-border-color: $light-gray;
 
 // Flash Colors
+$alert-color: $light-yellow;
 $error-color: $light-red;
 $notice-color: $light-yellow;
 $success-color: $light-green;


### PR DESCRIPTION
In recent projects using bitters, I have noticed that rails flash "alerts" were not automatically styled by Bitters like the rest of the flash message types and I have manually been adding them in like this. I think this would be great to also have included by default.
