### PR TITLE
Update installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Requirements
 ===
 - Sass 3.0+
 - Bourbon 2.0+
+- Ruby 1.9.3+
 
 Credits
 ===


### PR DESCRIPTION
- Note that the CLI requires Ruby 1.9.3 or higher
- Suggest running `rbenv rehash` after installing the bitters gem
