### PR TITLE
Add picture element, general cleanup

### DIFF
--- a/app/assets/stylesheets/_base.scss
+++ b/app/assets/stylesheets/_base.scss
@@ -2,21 +2,21 @@
 // http://bitters.bourbon.io
 
 // Variables
-@import 'variables';
+@import "variables";
 
 // Neat Settings -- uncomment if using Neat -- must be imported before Neat
-// @import 'grid-settings';
+// @import "grid-settings";
 
 // Extends
-@import 'extends/button';
-@import 'extends/clearfix';
-@import 'extends/errors';
-@import 'extends/flashes';
-@import 'extends/hide-text';
+@import "extends/button";
+@import "extends/clearfix";
+@import "extends/errors";
+@import "extends/flashes";
+@import "extends/hide-text";
 
 // Typography and Elements
-@import 'typography';
-@import 'forms';
-@import 'tables';
-@import 'lists';
-@import 'buttons';
+@import "typography";
+@import "forms";
+@import "tables";
+@import "lists";
+@import "buttons";

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -60,7 +60,8 @@ input[type="search"] {
   @include appearance(none);
 }
 
-input[type="checkbox"], input[type="radio"] {
+input[type="checkbox"],
+input[type="radio"] {
   display: inline;
   margin-right: $base-spacing / 4;
 }

--- a/app/assets/stylesheets/_grid-settings.scss
+++ b/app/assets/stylesheets/_grid-settings.scss
@@ -1,4 +1,4 @@
-@import 'neat-helpers'; // or '../neat/neat-helpers' when not in Rails
+@import "neat-helpers"; // or "../neat/neat-helpers" when not in Rails
 
 // Neat Overrides
 // $column: 90px;

--- a/app/assets/stylesheets/_lists.scss
+++ b/app/assets/stylesheets/_lists.scss
@@ -1,4 +1,5 @@
-ul, ol {
+ul,
+ol {
   margin: 0;
   padding: 0;
   list-style-type: none;

--- a/app/assets/stylesheets/_tables.scss
+++ b/app/assets/stylesheets/_tables.scss
@@ -17,6 +17,8 @@ td {
   padding: ($base-spacing / 2) 0;
 }
 
-tr, td, th {
+tr,
+td,
+th {
   vertical-align: middle;
 }

--- a/app/assets/stylesheets/_typography.scss
+++ b/app/assets/stylesheets/_typography.scss
@@ -7,7 +7,12 @@ body {
   line-height: $base-line-height;
 }
 
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   font-family: $header-font-family;
   line-height: $header-line-height;
   margin: 0;
@@ -65,7 +70,8 @@ hr {
   margin: $base-spacing 0;
 }
 
-img {
+img,
+picture {
   margin: 0;
   max-width: 100%;
 }
@@ -82,6 +88,6 @@ cite {
   font-style: italic;
 
   &:before {
-    content: '\2014 \00A0';
+    content: "\2014 \00A0";
   }
 }

--- a/app/assets/stylesheets/extends/_button.scss
+++ b/app/assets/stylesheets/extends/_button.scss
@@ -7,7 +7,7 @@
   font-size: $base-font-size;
   font-weight: bold;
   line-height: 1;
-  padding: .75em 1em;
+  padding: 0.75em 1em;
   text-decoration: none;
 
   &:hover {

--- a/spec/fixtures/application.scss
+++ b/spec/fixtures/application.scss
@@ -1,2 +1,2 @@
-@import 'bourbon';
-@import 'base/base';
+@import "bourbon";
+@import "base/base";


### PR DESCRIPTION
- Added `picture` to the `img { max-width: 100%`; } trick for responsive design now that we are starting to see browser support
- Swapped single prime marks in favor of double prime marks
- Broke multiple selectors to new lines, for consistency
- Prefixed decimals with a zero, for consistency
