### PR TITLE
Change to standard CSS comment for manifest version

### DIFF
--- a/app/assets/stylesheets/_base.scss
+++ b/app/assets/stylesheets/_base.scss
@@ -1,5 +1,7 @@
-// Bitters v0.10.0
-// http://bitters.bourbon.io
+/* Bitters 0.10.0
+ * http://bitters.bourbon.io
+ * Copyright 2013–2014 thoughtbot, inc.
+ * MIT License */
 
 // Variables
 @import 'variables';


### PR DESCRIPTION
Per [this PR](https://github.com/thoughtbot/bourbon/pull/476) for Bourbon, this is a slight modification to how we handle version info in the main manifest file.
