### PR TITLE
Add :disabled state to button placeholder

### DIFF
--- a/app/assets/stylesheets/extends/_button.scss
+++ b/app/assets/stylesheets/extends/_button.scss
@@ -14,4 +14,9 @@
     background-color: $hover-button-color;
     color: white;
   }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
 }


### PR DESCRIPTION
This brings the functionality that previously existed in Bourbon into Bitters.

Closes #87

See [Bourbon’s _button.scss lines 51–54](https://github.com/thoughtbot/bourbon/blob/dd86698/app/assets/stylesheets/addons/_button.scss#L51-L54) for the original code/inspiration.
