### PR TITLE
Revise font-feature-settings to more modern syntax

### DIFF
--- a/app/assets/stylesheets/_tables.scss
+++ b/app/assets/stylesheets/_tables.scss
@@ -1,4 +1,5 @@
 table {
+  @include font-feature-settings("kern","liga","tnum");
   border-collapse: collapse;
   margin: ($base-spacing / 2) 0;
   table-layout: fixed;

--- a/app/assets/stylesheets/_typography.scss
+++ b/app/assets/stylesheets/_typography.scss
@@ -1,4 +1,5 @@
 body {
+  @include font-feature-settings("kern","liga","frac", "pnum");
   -webkit-font-smoothing: antialiased;
   background-color: $base-background-color;
   color: $base-font-color;
@@ -16,7 +17,6 @@ h6 {
   font-family: $header-font-family;
   line-height: $header-line-height;
   margin: 0;
-  text-rendering: optimizeLegibility; // Fix the character spacing for headings
 }
 
 h1 {

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -1,7 +1,5 @@
 // Typography
-$sans-serif: $helvetica;
-$serif: $georgia;
-$base-font-family: $sans-serif;
+$base-font-family: $helvetica;
 $header-font-family: $base-font-family;
 
 // Font Sizes


### PR DESCRIPTION
Currently bitters uses the `optimize-legibility` attribute which has a very inconsistent.

When in a table, the declaration uses `"tnum"` which makes the numbers monospace (in spacing, not in font) which is more consistent with how tabular data is represented. 
