### PR TITLE
Update Buttons section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ All lists have stripped out styles. No bullets, no left padding. To add back the
 Adds basic styles all form elements. The variables at the top of the file all inherit from the variables file but make it really easy to be overridden.
 
 ### Buttons
-Basic style for `button` and `input[type="submit"]`. Button style can be changed by setting the `$button-style` variable to one of the [Bourbon](http://bourbon.io) button style [options](http://bourbon.io/docs/#buttons).
+Basic style for `button` and `input[type="submit"]`. Base button styles can be changed by modifying the `%button` extend in `base/extends/_button.scss`.
 
 ### Flashes
 Used for any error, warning or success messages in applications or forms. Specifically made for [Rails](http://rubyonrails.org) application notices.


### PR DESCRIPTION
Was referencing `$button-style` hook that was removed in ca2b6170a3ee399824d254e52a021d8d72cf9fe3

Looking at the differences between `base/extends/_button.scss` and `base/_button.scss`, I assumed the extend is where default button styles should go.  The latter file seems intended for reasonable defaults / resets instead of styles.  Happy to update the text if this isn't the case.  
