### PR TITLE
Fix typo

### DIFF
--- a/example.html
+++ b/example.html
@@ -177,7 +177,7 @@ class: example
     <span>This is an error message <a href="#">with a link</a></span>
   </div>
   <div class="notice">
-    <span>This is an notice message <a href="#">with a link</a></span>
+    <span>This is a notice message <a href="#">with a link</a></span>
   </div>
   <div class="alert">
     <span>This is an alert message <a href="#">with a link</a></span>


### PR DESCRIPTION
Fix a typo on example page (`an notice` -> `a notice`).
