### PR TITLE
Changes uncomment location if using neat in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For command line help, use `bitters help` or visit the [Command Line Interface W
   @import "base/base";
   ```
 
-5. When using Neat, uncomment the following line in `_base.scss`:
+5. When using Neat, uncomment the following line in `_bitters.scss`:
 
   ```scss
   @import "grid-settings";


### PR DESCRIPTION
In the readme it says if using neat we should uncomment 'grid-settings' in _base.scss. However it should be  _bitters.scss
