### PR TITLE
Catch font smoothing on all body elements

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -1,3 +1,9 @@
+#{$all-text-inputs},
+textarea {
+  font-family: inherit;
+  -webkit-font-smoothing: inherit;
+}
+
 fieldset {
   background: lighten($base-border-color, 10);
   border: $base-border;

--- a/app/assets/stylesheets/_typography.scss
+++ b/app/assets/stylesheets/_typography.scss
@@ -4,14 +4,8 @@ body {
   color: $base-font-color;
   font-family: $base-font-family;
   font-size: $base-font-size;
-  line-height: $base-line-height;
   -webkit-font-smoothing: antialiased;
-  
-  #{$all-text-inputs},
-  textarea {
-    font-family: inherit;
-    -webkit-font-smoothing: inherit;
-  }
+  line-height: $base-line-height;
 }
 
 h1,

--- a/app/assets/stylesheets/_typography.scss
+++ b/app/assets/stylesheets/_typography.scss
@@ -5,6 +5,7 @@ body {
   font-family: $base-font-family;
   font-size: $base-font-size;
   line-height: $base-line-height;
+  -webkit-font-smoothing: antialiased;
   
   #{$all-text-inputs},
   textarea {

--- a/app/assets/stylesheets/_typography.scss
+++ b/app/assets/stylesheets/_typography.scss
@@ -8,8 +8,10 @@ body {
   font-size: $base-font-size;
   line-height: $base-line-height;
   
-  * {
-    -webkit-font-smoothing: antialiased;
+  #{$all-text-inputs},
+  textarea {
+    -webkit-font-smoothing: inherit;
+    font-family: inherit;
   }
 }
 

--- a/app/assets/stylesheets/_typography.scss
+++ b/app/assets/stylesheets/_typography.scss
@@ -8,8 +8,8 @@ body {
   
   #{$all-text-inputs},
   textarea {
-    -webkit-font-smoothing: inherit;
     font-family: inherit;
+    -webkit-font-smoothing: inherit;
   }
 }
 

--- a/app/assets/stylesheets/_typography.scss
+++ b/app/assets/stylesheets/_typography.scss
@@ -1,5 +1,3 @@
-
-
 body {
   @include font-feature-settings("kern","liga","frac", "pnum");
   background-color: $base-background-color;

--- a/app/assets/stylesheets/_typography.scss
+++ b/app/assets/stylesheets/_typography.scss
@@ -1,11 +1,16 @@
+
+
 body {
   @include font-feature-settings("kern","liga","frac", "pnum");
-  -webkit-font-smoothing: antialiased;
   background-color: $base-background-color;
   color: $base-font-color;
   font-family: $base-font-family;
   font-size: $base-font-size;
   line-height: $base-line-height;
+  
+  * {
+    -webkit-font-smoothing: antialiased;
+  }
 }
 
 h1,


### PR DESCRIPTION
`-webkit-font-smoothing` will not catch everything in `body`, this can be verified by creating a `<button>` on a screen next to a `<a class="button">` and noting the difference in font smoothing. This PR will fix font smoothing and keep it consistent across all HTML elements.