### PR TITLE
Add --syntax=sass option to Install task

### DIFF
--- a/lib/bitters.rb
+++ b/lib/bitters.rb
@@ -2,5 +2,4 @@ require "bitters/version"
 require "bitters/generator"
 
 module Bitters
-  # Your code goes here...
 end


### PR DESCRIPTION
I submit this update for review. It adds a `--syntax=[syntax]` option to `bitters install` which defaults to `scss` but allows a user to specify the `sass` syntax if they wish. It works by globbing for `scss` files in the newly created directory, running Sass's `sass-convert` command and deleting the leftover `scss` files. Sass comes with `sass-convert` so I felt okay about relying on its presence.

On the other hand, if someone were only using [libsass](https://github.com/sass/libsass) perhaps that `sass-convert` might not be available.

I'm also happy to fix the style matters mentioned by the @houndci bot.

Thanks in advance for feedback on this idea.