### PR TITLE
Remove a bunch of redundancy in variables and header text styles

### DIFF
--- a/app/assets/stylesheets/_buttons.scss
+++ b/app/assets/stylesheets/_buttons.scss
@@ -1,10 +1,10 @@
 #{$all-button-inputs} {
   -webkit-font-smoothing: antialiased;
   @include appearance(none);
-  background-color: $base-button-color;
+  background-color: $action-color;
   border-radius: $base-border-radius;
   border: none;
-  color: white;
+  color: #fff;
   cursor: pointer;
   display: inline-block;
   font-family: $base-font-family;
@@ -19,8 +19,8 @@
 
   &:hover,
   &:focus {
-    background-color: $hover-button-color;
-    color: white;
+    background-color: darken($action-color, 15);
+    color: #fff;
   }
 
   &:disabled {

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -1,7 +1,7 @@
 fieldset {
   background: lighten($base-border-color, 10);
   border: $base-border;
-  margin: 0 0 ($base-spacing / 2) 0;
+  margin: 0 0 $small-spacing;
   padding: $base-spacing;
 }
 
@@ -9,8 +9,8 @@ input,
 label,
 select {
   display: block;
-  font-family: $form-font-family;
-  font-size: $form-font-size;
+  font-family: $base-font-family;
+  font-size: $base-font-size;
 }
 
 label {
@@ -32,21 +32,21 @@ select[multiple=multiple] {
   @include box-sizing(border-box);
   @include transition(border-color);
   background-color: white;
-  border-radius: $form-border-radius;
-  border: 1px solid $form-border-color;
+  border-radius: $base-border-radius;
+  border: $base-border;
   box-shadow: $form-box-shadow;
-  font-family: $form-font-family;
-  font-size: $form-font-size;
+  font-family: $base-font-family;
+  font-size: $base-font-size;
   margin-bottom: $base-spacing / 2;
   padding: ($base-spacing / 3) ($base-spacing / 3);
   width: 100%;
 
   &:hover {
-    border-color: $form-border-color-hover;
+    border-color: darken($base-border-color, 10);
   }
 
   &:focus {
-    border-color: $form-border-color-focus;
+    border-color: $action-color;
     box-shadow: $form-box-shadow-focus;
     outline: none;
   }
@@ -67,7 +67,7 @@ input[type="radio"] {
 }
 
 input[type="file"] {
-  padding-bottom: $base-spacing / 2;
+  padding-bottom: $small-spacing;
   width: 100%;
 }
 

--- a/app/assets/stylesheets/_lists.scss
+++ b/app/assets/stylesheets/_lists.scss
@@ -6,23 +6,23 @@ ol {
 
   &%default-ul {
     list-style-type: disc;
-    margin-bottom: $base-spacing / 2;
+    margin-bottom: $small-spacing;
     padding-left: $base-spacing;
   }
 
   &%default-ol {
     list-style-type: decimal;
-    margin-bottom: $base-spacing / 2;
+    margin-bottom: $small-spacing;
     padding-left: $base-spacing;
   }
 }
 
 dl {
-  margin-bottom: $base-spacing / 2;
+  margin-bottom: $small-spacing;
 
   dt {
     font-weight: bold;
-    margin-top: $base-spacing / 2;
+    margin-top: $small-spacing;
   }
 
   dd {

--- a/app/assets/stylesheets/_tables.scss
+++ b/app/assets/stylesheets/_tables.scss
@@ -1,7 +1,7 @@
 table {
   @include font-feature-settings("kern","liga","tnum");
   border-collapse: collapse;
-  margin: ($base-spacing / 2) 0;
+  margin: $small-spacing 0;
   table-layout: fixed;
   width: 100%;
 }
@@ -9,13 +9,13 @@ table {
 th {
   border-bottom: 1px solid darken($base-border-color, 15);
   font-weight: bold;
-  padding: ($base-spacing / 2) 0;
+  padding: $small-spacing 0;
   text-align: left;
 }
 
 td {
   border-bottom: $base-border;
-  padding: ($base-spacing / 2) 0;
+  padding: $small-spacing 0;
 }
 
 tr,

--- a/app/assets/stylesheets/_typography.scss
+++ b/app/assets/stylesheets/_typography.scss
@@ -15,49 +15,28 @@ h4,
 h5,
 h6 {
   font-family: $header-font-family;
+  font-size: $base-font-size;
   line-height: $header-line-height;
-  margin: 0;
-}
-
-h1 {
-  font-size: $h1-font-size;
-}
-
-h2 {
-  font-size: $h2-font-size;
-}
-
-h3 {
-  font-size: $h3-font-size;
-}
-
-h4 {
-  font-size: $h4-font-size;
-}
-
-h5 {
-  font-size: $h5-font-size;
-}
-
-h6 {
-  font-size: $h6-font-size;
+  margin: 0 0 $small-spacing;
 }
 
 p {
-  margin: 0 0 ($base-spacing / 2);
+  margin: 0 0 $small-spacing;
 }
 
 a {
   @include transition(color 0.1s linear);
-  color: $base-link-color;
+  color: $action-color;
   text-decoration: none;
 
+  &:active,
+  &:focus,
   &:hover {
-    color: $hover-link-color;
+    color: darken($action-color, 15);
   }
 
-  &:active, &:focus {
-    color: $hover-link-color;
+  &:active,
+  &:focus {
     outline: none;
   }
 }
@@ -74,20 +53,4 @@ img,
 picture {
   margin: 0;
   max-width: 100%;
-}
-
-blockquote {
-  border-left: 2px solid $base-border-color;
-  color: lighten($base-font-color, 15);
-  margin: $base-spacing 0;
-  padding-left: $base-spacing / 2;
-}
-
-cite {
-  color: lighten($base-font-color, 25);
-  font-style: italic;
-
-  &:before {
-    content: "\2014 \00A0";
-  }
 }

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -4,12 +4,6 @@ $header-font-family: $base-font-family;
 
 // Font Sizes
 $base-font-size: 1em;
-$h1-font-size: $base-font-size * 2.25;
-$h2-font-size: $base-font-size * 2;
-$h3-font-size: $base-font-size * 1.75;
-$h4-font-size: $base-font-size * 1.5;
-$h5-font-size: $base-font-size * 1.25;
-$h6-font-size: $base-font-size;
 
 // Line height
 $base-line-height: 1.5;
@@ -18,37 +12,24 @@ $header-line-height: 1.25;
 // Other Sizes
 $base-border-radius: 3px;
 $base-spacing: $base-line-height * 1em;
+$small-spacing: $base-spacing / 2;
 $base-z-index: 0;
 
 // Colors
-$blue: #477DCA;
+$blue: #477dca;
 $dark-gray: #333;
 $medium-gray: #999;
-$light-gray: #DDD;
-
-// Background Color
-$base-background-color: white;
+$light-gray: #ddd;
 
 // Font Colors
+$base-background-color: #fff;
 $base-font-color: $dark-gray;
-$base-accent-color: $blue;
+$action-color: $blue;
 
-// Link Colors
-$base-link-color: $base-accent-color;
-$hover-link-color: darken($base-accent-color, 15);
-$base-button-color: $base-link-color;
-$hover-button-color: $hover-link-color;
-
-// Border color
+// Border
 $base-border-color: $light-gray;
 $base-border: 1px solid $base-border-color;
 
 // Forms
-$form-border-color: $base-border-color;
-$form-border-color-hover: darken($base-border-color, 10);
-$form-border-color-focus: $base-accent-color;
-$form-border-radius: $base-border-radius;
-$form-box-shadow: inset 0 1px 3px rgba(black,0.06);
-$form-box-shadow-focus: $form-box-shadow, 0 0 5px rgba(darken($form-border-color-focus, 5), 0.7);
-$form-font-size: $base-font-size;
-$form-font-family: $base-font-family;
+$form-box-shadow: inset 0 1px 3px rgba(#000, 0.06);
+$form-box-shadow-focus: $form-box-shadow, 0 0 5px adjust-color($action-color, $lightness: -5%, $alpha: -0.3);

--- a/lib/bitters/generator.rb
+++ b/lib/bitters/generator.rb
@@ -21,7 +21,7 @@ module Bitters
     end
 
     desc 'reset', 'Reset Bitters'
-    def update
+    def reset
       if bitters_files_already_exist?
         remove_bitters_directory
         install_files


### PR DESCRIPTION
These changes are to  simplify bitters and are opinionated based on building web applications and not web sites.

* Remove header styles because they always get changed. The initial styles just add overhead to be changed. 
* Remove `blockquote` and `cite` styles. I've hardly ever used them and changed them when I have.
* Create `$base-spacing-small` for all the places where we were using `$base-spacing / 2`
* Remove unnecessary duplication in form variables.
* Remove unnecessary duplication in link and button variables.
* Remove `$base-background-color` as it rarely is used more than once.
