### PR TITLE
Rename update command to reset

### DIFF
--- a/lib/bitters/generator.rb
+++ b/lib/bitters/generator.rb
@@ -21,7 +21,7 @@ module Bitters
     end
 
     desc 'reset', 'Reset Bitters'
-    def update
+    def reset
       if bitters_files_already_exist?
         remove_bitters_directory
         install_files


### PR DESCRIPTION
For some reason in [this commit](https://github.com/thoughtbot/bitters/commit/8fc7ee22bf75aa63b0dd11e9bc6bd865e6d89ef6), `update` was supposed to be renamed to `reset` but was only updated in the instructions.