### PR TITLE
Refine and clean up stylesheets

### DIFF
--- a/app/assets/stylesheets/_base.scss
+++ b/app/assets/stylesheets/_base.scss
@@ -3,15 +3,13 @@
 // Copyright 2013-2015 thoughtbot, inc.
 // MIT License
 
-// Variables
 @import "variables";
 
 // Neat Settings -- uncomment if using Neat -- must be imported before Neat
 // @import "grid-settings";
 
-// Typography and Elements
-@import "typography";
-@import "forms";
-@import "tables";
-@import "lists";
 @import "buttons";
+@import "forms";
+@import "lists";
+@import "tables";
+@import "typography";

--- a/app/assets/stylesheets/_buttons.scss
+++ b/app/assets/stylesheets/_buttons.scss
@@ -1,6 +1,7 @@
-#{$all-button-inputs} {
-  -webkit-font-smoothing: antialiased;
+#{$all-button-inputs},
+button {
   @include appearance(none);
+  -webkit-font-smoothing: antialiased;
   background-color: $action-color;
   border-radius: $base-border-radius;
   border: none;
@@ -9,7 +10,7 @@
   display: inline-block;
   font-family: $base-font-family;
   font-size: $base-font-size;
-  font-weight: bold;
+  font-weight: 600;
   line-height: 1;
   padding: 0.75em 1em;
   text-decoration: none;
@@ -19,7 +20,7 @@
 
   &:hover,
   &:focus {
-    background-color: darken($action-color, 15);
+    background-color: darken($action-color, 15%);
     color: #fff;
   }
 

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -1,5 +1,5 @@
 fieldset {
-  background: lighten($base-border-color, 10);
+  background-color: lighten($base-border-color, 10%);
   border: $base-border;
   margin: 0 0 $small-spacing;
   padding: $base-spacing;
@@ -14,10 +14,10 @@ select {
 }
 
 label {
-  font-weight: bold;
-  margin-bottom: $base-spacing / 4;
+  font-weight: 600;
+  margin-bottom: $small-spacing / 2;
 
-  &.required:after {
+  &.required::after {
     content: "*";
   }
 
@@ -26,23 +26,23 @@ label {
   }
 }
 
-textarea,
 #{$all-text-inputs},
-select[multiple=multiple] {
-  @include box-sizing(border-box);
-  @include transition(border-color);
-  background-color: white;
-  border-radius: $base-border-radius;
+select[multiple=multiple],
+textarea {
+  background-color: $base-background-color;
   border: $base-border;
+  border-radius: $base-border-radius;
   box-shadow: $form-box-shadow;
+  box-sizing: border-box;
   font-family: $base-font-family;
   font-size: $base-font-size;
   margin-bottom: $base-spacing / 2;
-  padding: ($base-spacing / 3) ($base-spacing / 3);
+  padding: $base-spacing / 3;
+  transition: border-color;
   width: 100%;
 
   &:hover {
-    border-color: darken($base-border-color, 10);
+    border-color: darken($base-border-color, 10%);
   }
 
   &:focus {
@@ -63,7 +63,7 @@ input[type="search"] {
 input[type="checkbox"],
 input[type="radio"] {
   display: inline;
-  margin-right: $base-spacing / 4;
+  margin-right: $small-spacing / 2;
 }
 
 input[type="file"] {

--- a/app/assets/stylesheets/_lists.scss
+++ b/app/assets/stylesheets/_lists.scss
@@ -1,8 +1,8 @@
 ul,
 ol {
+  list-style-type: none;
   margin: 0;
   padding: 0;
-  list-style-type: none;
 
   &%default-ul {
     list-style-type: disc;

--- a/app/assets/stylesheets/_tables.scss
+++ b/app/assets/stylesheets/_tables.scss
@@ -1,5 +1,5 @@
 table {
-  @include font-feature-settings("kern","liga","tnum");
+  @include font-feature-settings("kern", "liga", "tnum");
   border-collapse: collapse;
   margin: $small-spacing 0;
   table-layout: fixed;
@@ -7,8 +7,8 @@ table {
 }
 
 th {
-  border-bottom: 1px solid darken($base-border-color, 15);
-  font-weight: bold;
+  border-bottom: 1px solid darken($base-border-color, 15%);
+  font-weight: 600;
   padding: $small-spacing 0;
   text-align: left;
 }

--- a/app/assets/stylesheets/_typography.scss
+++ b/app/assets/stylesheets/_typography.scss
@@ -1,7 +1,6 @@
 body {
-  @include font-feature-settings("kern","liga","frac", "pnum");
+  @include font-feature-settings("kern", "liga", "pnum");
   -webkit-font-smoothing: antialiased;
-  background-color: $base-background-color;
   color: $base-font-color;
   font-family: $base-font-family;
   font-size: $base-font-size;
@@ -14,9 +13,9 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: $header-font-family;
+  font-family: $heading-font-family;
   font-size: $base-font-size;
-  line-height: $header-line-height;
+  line-height: $heading-line-height;
   margin: 0 0 $small-spacing;
 }
 
@@ -25,14 +24,14 @@ p {
 }
 
 a {
-  @include transition(color 0.1s linear);
   color: $action-color;
   text-decoration: none;
+  transition: color 0.1s linear;
 
   &:active,
   &:focus,
   &:hover {
-    color: darken($action-color, 15);
+    color: darken($action-color, 15%);
   }
 
   &:active,

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -1,13 +1,13 @@
 // Typography
 $base-font-family: $helvetica;
-$header-font-family: $base-font-family;
+$heading-font-family: $base-font-family;
 
 // Font Sizes
 $base-font-size: 1em;
 
 // Line height
 $base-line-height: 1.5;
-$header-line-height: 1.25;
+$heading-line-height: 1.2;
 
 // Other Sizes
 $base-border-radius: 3px;


### PR DESCRIPTION
- Add percentage unit for color functions
- Change $header- variable name to $heading- (this better aligns with the HTML element naming—`H1` is heading 1, not header 1)
- Change keyword font weights to number values
- Remove fraction font feature settings from body
- Remove prefixes for box-sizing and transition
- Alphabetize properties