### PR TITLE
Add variables that set the theme for Refills

### DIFF
--- a/app/assets/stylesheets/_buttons.scss
+++ b/app/assets/stylesheets/_buttons.scss
@@ -2,7 +2,7 @@
 button {
   @include appearance(none);
   -webkit-font-smoothing: antialiased;
-  background-color: $action-color;
+  background-color: $action-color-on-background;
   border-radius: $base-border-radius;
   border: none;
   color: #fff;
@@ -20,7 +20,7 @@ button {
 
   &:hover,
   &:focus {
-    background-color: darken($action-color, 15%);
+    background-color: darken($action-color-on-background, 15%);
     color: #fff;
   }
 

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -1,5 +1,5 @@
 fieldset {
-  background-color: lighten($base-border-color, 10%);
+  background-color: $base-box-background;
   border: $base-border;
   margin: 0 0 $small-spacing;
   padding: $base-spacing;
@@ -9,8 +9,8 @@ input,
 label,
 select {
   display: block;
-  font-family: $base-font-family;
-  font-size: $base-font-size;
+  // font-family: $base-font-family;
+  // font-size: $base-font-size;
 }
 
 label {
@@ -29,8 +29,8 @@ label {
 #{$all-text-inputs},
 select[multiple=multiple],
 textarea {
-  background-color: $base-background-color;
-  border: $base-border;
+  background-color: $form-background;
+  border: $form-border;
   border-radius: $base-border-radius;
   box-shadow: $form-box-shadow;
   box-sizing: border-box;
@@ -42,11 +42,11 @@ textarea {
   width: 100%;
 
   &:hover {
-    border-color: darken($base-border-color, 10%);
+    border-color: darken($form-border-color, 10%);
   }
 
   &:focus {
-    border-color: $action-color;
+    border-color: $action-color-on-box;
     box-shadow: $form-box-shadow-focus;
     outline: none;
   }

--- a/app/assets/stylesheets/_typography.scss
+++ b/app/assets/stylesheets/_typography.scss
@@ -1,7 +1,7 @@
 body {
   @include font-feature-settings("kern", "liga", "pnum");
   -webkit-font-smoothing: antialiased;
-  color: $base-font-color;
+  color: $base-font-color-on-background;
   font-family: $base-font-family;
   font-size: $base-font-size;
   line-height: $base-line-height;
@@ -24,14 +24,14 @@ p {
 }
 
 a {
-  color: $action-color;
+  color: $action-color-on-background;
   text-decoration: none;
   transition: color 0.1s linear;
 
   &:active,
   &:focus,
   &:hover {
-    color: darken($action-color, 15%);
+    color: darken($action-color-on-background, 15%);
   }
 
   &:active,

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -7,7 +7,7 @@ $base-font-size: 1em;
 
 // Line height
 $base-line-height: 1.5;
-$heading-line-height: 1.2;
+$heading-line-height: 1.25;
 
 // Other Sizes
 $base-border-radius: 3px;
@@ -16,20 +16,54 @@ $small-spacing: $base-spacing / 2;
 $base-z-index: 0;
 
 // Colors
-$blue: #477dca;
-$dark-gray: #333;
-$medium-gray: #999;
-$light-gray: #ddd;
+$dark-color: #333;
+$light-color: #fff;
 
-// Font Colors
-$base-background-color: #fff;
-$base-font-color: $dark-gray;
-$action-color: $blue;
+// Background
+$base-background: #fff;
+$base-background-inset: darken($base-background, 4%);
+$base-background-inset-shadow: inset 0 0 2px darken($base-background, 20%);
+$base-font-color-on-background: $dark-color;
 
-// Border
-$base-border-color: $light-gray;
+// Outline on background
+$base-outline-color: darken($base-background, 15%);
+$base-outline: 1px solid $base-outline-color;
+
+// Box
+$base-box-background: darken($base-background, 3%);
+$base-border-color: darken($base-box-background, 15%);
 $base-border: 1px solid $base-border-color;
+$base-box-background-inset: darken($base-box-background, 5%);
+$base-font-color-on-box: #000;
+$base-box-shadow: 0 1px 2px transparentize($base-font-color-on-box, 0.8);
+$base-box-shadow-inset: inset 0 2px 2px darken($base-box-background, 10%);
+
+// Notification Colors
+$alert-color: #fff6bf;
+$error-color: #fbe3e4;
+$notice-color: #e5edf8;
+$success-color: #e6efc2;
+
+// Action Colors
+$action-color-on-background: #477dca;
+$action-color-on-box: #477dca;
 
 // Forms
+$form-background: #fff;
+$form-border-color: $base-border-color;
+$form-border: 1px solid $form-border-color;
 $form-box-shadow: inset 0 1px 3px rgba(#000, 0.06);
-$form-box-shadow-focus: $form-box-shadow, 0 0 5px adjust-color($action-color, $lightness: -5%, $alpha: -0.3);
+$form-box-shadow-focus: $form-box-shadow, 0 0 5px adjust-color($action-color-on-background, $lightness: -5%, $alpha: -0.3);
+
+// Media
+$medium-screen: em(640);
+$large-screen: em(860);
+
+body {
+  @include font-feature-settings("kern", "liga", "frac", "pnum");
+  background-color: $base-background;
+  font-family: $base-font-family;
+  font-size: $base-font-size;
+  -webkit-font-smoothing: antialiased;
+  line-height: $base-line-height;
+}


### PR DESCRIPTION
For Refills we are planning on adding a global variable stylesheet to enable the creation of themes. 
The idea is to make all Refills components and patterns depend on the same style rules, so if you change something in the variable file all Refills will be affected.
This PR adds those variables.

If we would find a set of variable names that could apply for both Bitters and Refills I think we would find a nice interface between the two.
Refills would still be independent, but if you add Bitters you get better base styles for things you might add.

Since Refills only adds a variable stylesheet, the `body` styles are placed in the variables file. 
I have a feeling there will be a debate around that but I don't see a better solution right now.

The basic idea is to provide rules for:
- The background: Color for background, color for font on background, inset on a background, etc.
- A box (or a container element): Color for box background etc.
- Generic colors

