### PR TITLE
Add secondary background color variable

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -1,5 +1,5 @@
 fieldset {
-  background-color: lighten($base-border-color, 10%);
+  background-color: $secondary-background-color;
   border: $base-border;
   margin: 0 0 $small-spacing;
   padding: $base-spacing;

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -22,13 +22,16 @@ $medium-gray: #999;
 $light-gray: #ddd;
 
 // Font Colors
-$base-background-color: #fff;
 $base-font-color: $dark-gray;
 $action-color: $blue;
 
 // Border
 $base-border-color: $light-gray;
 $base-border: 1px solid $base-border-color;
+
+// Background Colors
+$base-background-color: #fff;
+$secondary-background-color: lighten($base-border-color, 10%);
 
 // Forms
 $form-box-shadow: inset 0 1px 3px rgba(#000, 0.06);


### PR DESCRIPTION
This PR turns the formfield background color into a variable.
Reason for this is that it would be very useful for Refills, and apps in general, to have a "box" or "container" color defined like this.

