### PR TITLE
Add explicit diplay properties to input elements

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -8,7 +8,6 @@ fieldset {
 input,
 label,
 select {
-  display: block;
   font-family: $base-font-family;
   font-size: $base-font-size;
 }
@@ -34,6 +33,7 @@ textarea {
   border-radius: $base-border-radius;
   box-shadow: $form-box-shadow;
   box-sizing: border-box;
+  display: block;
   font-family: $base-font-family;
   font-size: $base-font-size;
   margin-bottom: $base-spacing / 2;


### PR DESCRIPTION
The default properties for `textarea` and other form inputs set their to `display: inline-block; which can have strange implications for its spacing and bottom margin.