### PR TITLE
Update for Bourbon 4.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in bitters.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ for updates.
 
 ## Requirements
 
-- [Sass](https://github.com/sass/sass) 3.0+
-- [Bourbon](https://github.com/thoughtbot/bourbon) 2.0+
+- [Sass](https://github.com/sass/sass) 3.4+ or [LibSass](https://github.com/sass/libsass) 3.1+
+- [Bourbon](https://github.com/thoughtbot/bourbon) 4.2+
 - Ruby 1.9.3+ (required to install Bitters from the command line)
 
 ## Installation

--- a/app/assets/stylesheets/_buttons.scss
+++ b/app/assets/stylesheets/_buttons.scss
@@ -1,5 +1,4 @@
-#{$all-button-inputs},
-button {
+#{$all-buttons} {
   @include appearance(none);
   background-color: $action-color;
   border: none;

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -26,8 +26,7 @@ label {
 }
 
 #{$all-text-inputs},
-select[multiple=multiple],
-textarea {
+select[multiple=multiple] {
   background-color: $base-background-color;
   border: $base-border;
   border-radius: $base-border-radius;
@@ -36,7 +35,7 @@ textarea {
   display: block;
   font-family: $base-font-family;
   font-size: $base-font-size;
-  margin-bottom: $base-spacing / 2;
+  margin-bottom: $small-spacing;
   padding: $base-spacing / 3;
   transition: border-color;
   width: 100%;

--- a/bitters.gemspec
+++ b/bitters.gemspec
@@ -27,7 +27,7 @@ design and brand requirements.
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
 
-  s.add_dependency 'bourbon', '>= 3.2'
-  s.add_dependency 'sass', '>= 3.2'
+  s.add_dependency 'bourbon', '>= 4.2'
+  s.add_dependency 'sass', '>= 3.4'
   s.add_dependency 'thor'
 end


### PR DESCRIPTION
Slight tweaks:

- As of Bourbon 4.2, `#{$all-text-inputs}` now _includes_ `textarea`
- As of Bourbon 4.2, `#{$all-button-inputs}` is now `#{$all-buttons}` (Ref: https://github.com/thoughtbot/bourbon/commit/a6374b6be375737cdfcb081d3a668b4865692038)
- Increase version requirements