### PR TITLE
add style to select boxes that have the "size" property

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -28,6 +28,7 @@ label {
 
 #{$all-text-inputs},
 select[multiple=multiple],
+select:not([size=""]),
 textarea {
   background-color: $base-background-color;
   border: $base-border;
@@ -65,6 +66,8 @@ textarea {
   resize: vertical;
 }
 
+select[multiple=multiple],
+select:not([size=""]),
 input[type="search"] {
   @include appearance(none);
 }


### PR DESCRIPTION
Style for `<select multiple="multiple">` was already similar to regular input boxes, but it has an implicit `size=5` attribute. When select boxes are created with explicitely set `size=X` all the nice styles of `select[multiple]` are not being used.

in Chrome to make select boxes apply padding (like input boxes) it was also required to `@include appearance(none);`  as per [stackoverflow.com/a/27508479/11414](https://stackoverflow.com/a/27508479/11414).