### PR TITLE
Do not remove outline on focus

### DIFF
--- a/app/assets/stylesheets/_typography.scss
+++ b/app/assets/stylesheets/_typography.scss
@@ -32,11 +32,6 @@ a {
   &:hover {
     color: shade($action-color, 25%);
   }
-
-  &:active,
-  &:focus {
-    outline: none;
-  }
 }
 
 hr {


### PR DESCRIPTION
- Removing outline breaks applications for people who use keyboard only for
  navigation (people with motor skill impairments for example)
- This change needs to be clearly signaled in the release it's a part of, since it will probably be unexpected to see an outline appear on upgrading the library in an app.

[closes #172]