### PR TITLE
Refine button

### DIFF
--- a/app/assets/stylesheets/_buttons.scss
+++ b/app/assets/stylesheets/_buttons.scss
@@ -27,5 +27,9 @@
   &:disabled {
     cursor: not-allowed;
     opacity: 0.5;
+
+    &:hover {
+      background-color: $action-color;
+    }
   }
 }

--- a/app/assets/stylesheets/_buttons.scss
+++ b/app/assets/stylesheets/_buttons.scss
@@ -11,7 +11,7 @@
   -webkit-font-smoothing: antialiased;
   font-weight: 600;
   line-height: 1;
-  padding: ($small-spacing / 1.2) ($base-spacing / 1.2);
+  padding: $small-spacing $base-spacing;
   text-decoration: none;
   transition: background-color $base-duration $base-timing;
   user-select: none;

--- a/app/assets/stylesheets/_buttons.scss
+++ b/app/assets/stylesheets/_buttons.scss
@@ -11,7 +11,7 @@
   -webkit-font-smoothing: antialiased;
   font-weight: 600;
   line-height: 1;
-  padding: 0.75em 1em;
+  padding: ($small-spacing / 1.2) ($base-spacing / 1.2);
   text-decoration: none;
   transition: background-color $base-duration $base-timing;
   user-select: none;


### PR DESCRIPTION
- Tweak the size, make it less tall (screenshot below, after on the right)
- Remove hover transition when button has the `disabled` attribute (just like what was added [here](https://github.com/thoughtbot/bitters/commit/2ad54f54bb92d1d4065480334d5c949cea238b07) for text inputs)

![button](https://cloud.githubusercontent.com/assets/903327/7779582/c147b80e-00a3-11e5-9c50-34bd8fb2f911.jpg)