### PR TITLE
Refine transitions

### DIFF
--- a/app/assets/stylesheets/_buttons.scss
+++ b/app/assets/stylesheets/_buttons.scss
@@ -13,7 +13,7 @@
   line-height: 1;
   padding: 0.75em 1em;
   text-decoration: none;
-  transition: background-color 150ms ease;
+  transition: background-color $base-duration $base-timing;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;

--- a/app/assets/stylesheets/_buttons.scss
+++ b/app/assets/stylesheets/_buttons.scss
@@ -13,6 +13,7 @@
   line-height: 1;
   padding: 0.75em 1em;
   text-decoration: none;
+  transition: background-color 150ms ease;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -37,7 +37,7 @@ select[multiple=multiple] {
   font-size: $base-font-size;
   margin-bottom: $small-spacing;
   padding: $base-spacing / 3;
-  transition: border-color 150ms ease;
+  transition: border-color $base-duration $base-timing;
   width: 100%;
 
   &:hover {

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -37,7 +37,7 @@ select[multiple=multiple] {
   font-size: $base-font-size;
   margin-bottom: $small-spacing;
   padding: $base-spacing / 3;
-  transition: border-color;
+  transition: border-color 150ms ease;
   width: 100%;
 
   &:hover {

--- a/app/assets/stylesheets/_typography.scss
+++ b/app/assets/stylesheets/_typography.scss
@@ -25,7 +25,7 @@ p {
 a {
   color: $action-color;
   text-decoration: none;
-  transition: color 0.1s linear;
+  transition: color 150ms ease;
 
   &:active,
   &:focus,

--- a/app/assets/stylesheets/_typography.scss
+++ b/app/assets/stylesheets/_typography.scss
@@ -25,7 +25,7 @@ p {
 a {
   color: $action-color;
   text-decoration: none;
-  transition: color 150ms ease;
+  transition: color $base-duration $base-timing;
 
   &:active,
   &:focus,

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -36,3 +36,7 @@ $secondary-background-color: lighten($base-border-color, 10%);
 // Forms
 $form-box-shadow: inset 0 1px 3px rgba(#000, 0.06);
 $form-box-shadow-focus: $form-box-shadow, 0 0 5px adjust-color($action-color, $lightness: -5%, $alpha: -0.3);
+
+// Animations
+$base-duration: 150ms;
+$base-timing: ease;


### PR DESCRIPTION
- Add missing transition for `background-color` on buttons
- Consistently use `ms` instead of `s` units