### PR TITLE
Remove em function

### DIFF
--- a/app/assets/stylesheets/_grid-settings.scss
+++ b/app/assets/stylesheets/_grid-settings.scss
@@ -4,11 +4,11 @@
 // $column: 90px;
 // $gutter: 30px;
 // $grid-columns: 12;
-// $max-width: em(1088);
+// $max-width: 1200px;
 
 // Neat Breakpoints
-$medium-screen: em(640);
-$large-screen: em(860);
+$medium-screen: 600px;
+$large-screen: 900px;
 
 $medium-screen-up: new-breakpoint(min-width $medium-screen 4);
 $large-screen-up: new-breakpoint(min-width $large-screen 8);


### PR DESCRIPTION
The `em` function will be removed in Bourbon 5.0 and it’s also no longer necessary to define media queries in `em`’s. [This article](http://blog.cloudfour.com/the-ems-have-it-proportional-media-queries-ftw/) originally explained why `em`’s resolved weird zooming issues; but that’s no longer true and even the article was updated to indicate so.