### PR TITLE
Remove font-smoothing on body

### DIFF
--- a/app/assets/stylesheets/_typography.scss
+++ b/app/assets/stylesheets/_typography.scss
@@ -3,7 +3,6 @@ body {
   font-family: $base-font-family;
   font-feature-settings: "kern", "liga", "pnum";
   font-size: $base-font-size;
-  -webkit-font-smoothing: antialiased;
   line-height: $base-line-height;
 }
 


### PR DESCRIPTION
`-webkit-font-smoothing` is [non-standard](https://developer.mozilla.org/en-US/docs/Web/CSS/font-smooth) and makes text look _worse_ on light backgrounds—which I think we more commonly see than dark backgrounds—graying the text slightly. I think it’s bad to apply this in such a global manner (on the `body`).

I purposely left `-webkit-font-smoothing` on the [button](https://github.com/thoughtbot/bitters/blob/master/app/assets/stylesheets/_buttons.scss), because it has a darker background and the text renders better with it on, in this use.

Some comparisons (all screenshots from my retina MacBook Pro):

![chrome-light-background](https://cloud.githubusercontent.com/assets/903327/7779875/7e254c8c-00a6-11e5-81dc-17910b304e36.jpg)
![chrome-dark-background](https://cloud.githubusercontent.com/assets/903327/7779882/8d5046e4-00a6-11e5-9d26-2237cfc91229.jpg)
