### PR TITLE
Revert "Add explicit diplay properties to input elements"

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -8,6 +8,7 @@ fieldset {
 input,
 label,
 select {
+  display: block;
   font-family: $base-font-family;
   font-size: $base-font-size;
 }
@@ -32,7 +33,6 @@ select[multiple=multiple] {
   border-radius: $base-border-radius;
   box-shadow: $form-box-shadow;
   box-sizing: border-box;
-  display: block;
   font-family: $base-font-family;
   font-size: $base-font-size;
   margin-bottom: $small-spacing;


### PR DESCRIPTION
This commit collapsed `label`’s and busted the layout:

### Currently

![screen shot 2015-05-27 at 4 58 39 pm](https://cloud.githubusercontent.com/assets/903327/7847569/6813116e-0492-11e5-86d7-af53ba56d88a.png)

### After _(what this revert brings back)_
![screen shot 2015-05-27 at 4 59 10 pm](https://cloud.githubusercontent.com/assets/903327/7847573/6e61d0b4-0492-11e5-91a8-c05079504bc0.png)