### PR TITLE
Swap padding for margin on file inputs

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -75,7 +75,7 @@ input[type="radio"] {
 }
 
 input[type="file"] {
-  padding-bottom: $small-spacing;
+  margin-bottom: $small-spacing;
   width: 100%;
 }
 


### PR DESCRIPTION
- Match the styles for other `input`’s which use `margin`, not `padding`
- `padding` makes the `focus` state look funny because it pushes the bottom of the `outline` down with it:

![screen shot 2015-05-27 at 10 04 58 pm](https://cloud.githubusercontent.com/assets/903327/7851377/caf03954-04bc-11e5-8573-befc3e1d759c.png)

## Fixed

![screen shot 2015-05-27 at 10 08 14 pm](https://cloud.githubusercontent.com/assets/903327/7851386/eb4b324e-04bc-11e5-8c59-642735eff488.png)
