### PR TITLE
Make labels after checkboxes/radio buttons display as inline-block

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -72,6 +72,10 @@ input[type="checkbox"],
 input[type="radio"] {
   display: inline;
   margin-right: $small-spacing / 2;
+
+  + label {
+    display: inline-block;
+  }
 }
 
 input[type="file"] {


### PR DESCRIPTION
This PR makes labels following a checkbox or radio button to display as `inline-block` rather than `block`.

Before:
![screen shot 2015-08-04 at 13 01 08](https://cloud.githubusercontent.com/assets/632942/9067024/0d1e4d12-3aa9-11e5-9350-2175cd5d9938.png)

After:
![screen shot 2015-08-04 at 13 01 17](https://cloud.githubusercontent.com/assets/632942/9067022/0a66651e-3aa9-11e5-92da-1831c1504564.png)

A couple things:

1. I don't have any preference for `inline-block` vs `inline`, the spacing just looks better in this case for `inline-block`.
2. This only works for labels that follow an input, not when labels are [wrapped around the input element](http://stackoverflow.com/questions/11992026/is-it-better-to-wrap-the-label-tag-around-a-form-item-or-use-the-for-attribute).

