### PR TITLE
Use SVG thoughtbot logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Copyright © 2013–2015 [thoughtbot, inc](http://thoughtbot.com). Bitters is fr
 
 ## About thoughtbot
 
-![thoughtbot](https://thoughtbot.com/logo.png)
+[<img src="http://thoughtbot.github.io/images/signature.svg" width="250" alt="thoughtbot logo">][hire]
 
 Bitters is maintained and funded by thoughtbot, inc.
 The names and logos for thoughtbot are trademarks of thoughtbot, inc.


### PR DESCRIPTION
The use of the `img` tag—rather than Markdown’s built-in image syntax—is so that we can control the size.

If we like this update, I’ll carry the same over to the Neat and Refills `README`’s.