### PR TITLE
Update `fieldset` styling

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -1,8 +1,14 @@
 fieldset {
-  background-color: $secondary-background-color;
-  border: $base-border;
-  margin: 0 0 $small-spacing;
-  padding: $base-spacing;
+  background-color: transparent;
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+legend {
+  font-weight: 600;
+  margin-bottom: $small-spacing / 2;
+  padding: 0;
 }
 
 input,


### PR DESCRIPTION
I’ve always found the default styling for `fieldset`’s too harsh, visually. Their purpose is to “group several controls as well as labels within a web form” ([1]). So, for example, you could group three individual inputs for month, day and year within a `fieldset` to represent a birthdate. For the sake of semantics, you would also give that `fieldset` a legend: `<legend>Birthdate</legend>`.

But if that `fieldset` was follow by an individual input that isn’t also grouped in a `fieldset` (so it doesn’t have all the spacing and `background-color`), they visually look _super_ different for almost no reason. So I say we clear out the visual styling of `fieldset`s:

- Remove `background-color`, `border`, `margin` and `padding` from `fieldset`
- Add `legend` styles to reflect updated `fieldset` styling

### Before

<img width="984" alt="screen shot 2015-09-24 at 5 25 30 pm" src="https://cloud.githubusercontent.com/assets/903327/10087513/46cda768-62e2-11e5-8c1c-e77561422525.png">

### After

<img width="984" alt="screen shot 2015-09-24 at 5 25 57 pm" src="https://cloud.githubusercontent.com/assets/903327/10087516/4a598956-62e2-11e5-8b53-3589e67986fe.png">

[1]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset "MDN"