### PR TITLE
Remove default list placeholders

### DIFF
--- a/app/assets/stylesheets/_lists.scss
+++ b/app/assets/stylesheets/_lists.scss
@@ -3,25 +3,13 @@ ol {
   list-style-type: none;
   margin: 0;
   padding: 0;
-
-  &%default-ul {
-    list-style-type: disc;
-    margin-bottom: $small-spacing;
-    padding-left: $base-spacing;
-  }
-
-  &%default-ol {
-    list-style-type: decimal;
-    margin-bottom: $small-spacing;
-    padding-left: $base-spacing;
-  }
 }
 
 dl {
   margin-bottom: $small-spacing;
 
   dt {
-    font-weight: bold;
+    font-weight: 600;
     margin-top: $small-spacing;
   }
 

--- a/contrib/index.html
+++ b/contrib/index.html
@@ -69,18 +69,6 @@
         <dt>Definition Term Title 3</dt>
         <dd>Definition term description</dd>
       </dl>
-      <h2><code>%default-ol</code> Ordered List</h2>
-      <ol class="default-ol">
-        <li>List Item 1</li>
-        <li>List Item 2</li>
-        <li>List Item 3</li>
-      </ol>
-      <h2><code>%default-ul</code> Unordered List</h2>
-      <ul class="default-ul">
-        <li>List Item 1</li>
-        <li>List Item 2</li>
-        <li>List Item 3</li>
-      </ul>
       <hr>
       <form>
         <label for="text_field">Text Field</label>

--- a/contrib/styles.scss
+++ b/contrib/styles.scss
@@ -11,14 +11,6 @@ body {
   max-width: 500px;
 }
 
-.default-ol {
-  @extend %default-ol;
-}
-
-.default-ul {
-  @extend %default-ul;
-}
-
 .welcome-message {
   @include padding($base-spacing null);
   background-color: #f2f2f2;


### PR DESCRIPTION
I’ve never used them…but does someone have a good example of these being handy?

If I want default lists back, there’s more to the story:

- Maybe it’s user-generated content, in which case more than just lists will need some styling; I would utilize a scope class
- Never a big fan of extends, and the few times I could see using these, I'd just rather write out a few standard CSS properties right where I need them