### PR TITLE
Remove font-feature-settings

### DIFF
--- a/app/assets/stylesheets/_tables.scss
+++ b/app/assets/stylesheets/_tables.scss
@@ -1,6 +1,5 @@
 table {
   border-collapse: collapse;
-  font-feature-settings: "kern", "liga", "tnum";
   margin: $small-spacing 0;
   table-layout: fixed;
   width: 100%;

--- a/app/assets/stylesheets/_typography.scss
+++ b/app/assets/stylesheets/_typography.scss
@@ -1,7 +1,6 @@
 body {
   color: $base-font-color;
   font-family: $base-font-family;
-  font-feature-settings: "kern", "liga", "pnum";
   font-size: $base-font-size;
   line-height: $base-line-height;
 }


### PR DESCRIPTION
This feature is still a little rough around the edges and has causes some major
rendering issues for people. See:

- https://github.com/thoughtbot/bitters/issues/200
- https://github.com/thoughtbot/bitters/issues/187
- https://github.com/thoughtbot/bitters/issues/155

Basically, turning font-feature-settings on in such a global way is a bit too
risky and can have major drawbacks, like no text showing.

This PR completely removes this CSS. Another route is that we leave it in, do much more testing and figure out exactly _where_ and _when_ issues arise and be very clear about browser support. It appears it _might_ be IE9 mostly?