### PR TITLE
Change select's margin-bottom to small-spacing

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -84,7 +84,7 @@ input[type="file"] {
 }
 
 select {
-  margin-bottom: $base-spacing;
+  margin-bottom: $small-spacing;
   max-width: 100%;
   width: auto;
 }


### PR DESCRIPTION
The `margin-bottom` of all text `input`'s, and `selects[multiple=multiple]` are `$small-spacing` (which is `$base-spacing / 2`).

But the `margin-bottom` of regular `select` is the full `$base-spacing`.

This PR standardizes `select` to have a `margin-bottom` of `$small-spacing` as well. I can't immediately think of a compelling reason why it should be bigger.

(I just made this change in a local project, so I figure it might be good to have here.)

:ok_woman: