### PR TITLE
HTML Validation

### DIFF
--- a/contrib/index.html
+++ b/contrib/index.html
@@ -110,35 +110,27 @@
           <input type="text" id="last_name" placeholder="Murray">
         </fieldset>
         <fieldset>
-          <legend>Fieldset</legend>
-          <label for="radio_buttons">Radio Buttons</label>
+          <legend>Radio Fieldset</legend>
           <label>
-            <input type="radio" value="radio_1">
-            Radio 1
+            <input type="radio" value="radio-1"> Radio 1
           </label>
           <label>
-            <input type="radio" value="radio_2">
-            Radio 2
+            <input type="radio" value="radio-2"> Radio 2
           </label>
           <label>
-            <input type="radio" value="radio_3">
-            Radio 3
+            <input type="radio" value="radio-3"> Radio 3
           </label>
         </fieldset>
         <fieldset>
-          <legend>Fieldset</legend>
-          <label for="checkboxes">Checkboxes</label>
+          <legend>Checkbox Fieldset</legend>
           <label>
-            <input type="checkbox" value="check_1" checked>
-            Checkbox 1
+            <input type="checkbox" value="check-1" checked> Checkbox 1
           </label>
           <label>
-            <input type="checkbox" value="check_2">
-            Checkbox 2
+            <input type="checkbox" value="check-2"> Checkbox 2
           </label>
           <label>
-            <input type="checkbox" value="check_3">
-            Checkbox 3
+            <input type="checkbox" value="check-3"> Checkbox 3
           </label>
         </fieldset>
         <input type="submit" value="Submit">

--- a/contrib/index.html
+++ b/contrib/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>Have fun ♥️</title>
     <link rel="stylesheet" href="styles.css">

--- a/contrib/index.html
+++ b/contrib/index.html
@@ -145,7 +145,7 @@
         <input type="submit" value="Disabled" disabled>
       </form>
       <hr>
-      <table cellspacing="0" cellpadding="0">
+      <table>
         <tr>
           <th>Table Header 1</th>
           <th>Table Header 2</th>


### PR DESCRIPTION
I ran the contributing page HTML through [W3C Markup Validation Service](https://validator.w3.org) and it returned a few warnings and errors. This PR resolves those:

- Updated the IE meta tag to the modern syntax (got this from HTML5 boilerplate)
- Removed `cellspacing` and `cellpadding` attributes from the table (it recommends to do this via CSS now)
- Removed the extraneous `label` that was attempting to be used for the radio and check `input` examples