### PR TITLE
Form improvements

### DIFF
--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -70,10 +70,6 @@ input[type="checkbox"],
 input[type="radio"] {
   display: inline;
   margin-right: $small-spacing / 2;
-
-  + label {
-    display: inline-block;
-  }
 }
 
 input[type="file"] {

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -18,10 +18,6 @@ label {
   &.required::after {
     content: "*";
   }
-
-  abbr {
-    display: none;
-  }
 }
 
 input,

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -62,17 +62,17 @@ textarea {
   resize: vertical;
 }
 
-input[type="search"] {
+[type="search"] {
   appearance: none;
 }
 
-input[type="checkbox"],
-input[type="radio"] {
+[type="checkbox"],
+[type="radio"] {
   display: inline;
   margin-right: $small-spacing / 2;
 }
 
-input[type="file"] {
+[type="file"] {
   margin-bottom: $small-spacing;
   width: 100%;
 }

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -11,14 +11,6 @@ legend {
   padding: 0;
 }
 
-input,
-label,
-select {
-  display: block;
-  font-family: $base-font-family;
-  font-size: $base-font-size;
-}
-
 label {
   font-weight: 600;
   margin-bottom: $small-spacing / 2;
@@ -30,6 +22,14 @@ label {
   abbr {
     display: none;
   }
+}
+
+input,
+label,
+select {
+  display: block;
+  font-family: $base-font-family;
+  font-size: $base-font-size;
 }
 
 #{$all-text-inputs},

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -12,12 +12,12 @@ legend {
 }
 
 label {
+  display: block;
   font-weight: 600;
   margin-bottom: $small-spacing / 2;
 }
 
 input,
-label,
 select {
   display: block;
   font-family: $base-font-family;

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -14,10 +14,6 @@ legend {
 label {
   font-weight: 600;
   margin-bottom: $small-spacing / 2;
-
-  &.required::after {
-    content: "*";
-  }
 }
 
 input,

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -25,7 +25,7 @@ select {
 }
 
 #{$all-text-inputs},
-select[multiple=multiple] {
+select[multiple] {
   background-color: $base-background-color;
   border: $base-border;
   border-radius: $base-border-radius;

--- a/contrib/index.html
+++ b/contrib/index.html
@@ -112,25 +112,25 @@
         <fieldset>
           <legend>Radio Fieldset</legend>
           <label>
-            <input type="radio" value="radio-1"> Radio 1
+            <input type="radio" name="radio-buttons" value="radio-1"> Radio 1
           </label>
           <label>
-            <input type="radio" value="radio-2"> Radio 2
+            <input type="radio" name="radio-buttons" value="radio-2"> Radio 2
           </label>
           <label>
-            <input type="radio" value="radio-3"> Radio 3
+            <input type="radio" name="radio-buttons" value="radio-3"> Radio 3
           </label>
         </fieldset>
         <fieldset>
           <legend>Checkbox Fieldset</legend>
           <label>
-            <input type="checkbox" value="check-1" checked> Checkbox 1
+            <input type="checkbox" name="checkboxes" value="check-1" checked> Checkbox 1
           </label>
           <label>
-            <input type="checkbox" value="check-2"> Checkbox 2
+            <input type="checkbox" name="checkboxes" value="check-2"> Checkbox 2
           </label>
           <label>
-            <input type="checkbox" value="check-3"> Checkbox 3
+            <input type="checkbox" name="checkboxes" value="check-3"> Checkbox 3
           </label>
         </fieldset>
         <input type="submit" value="Submit">


### PR DESCRIPTION
- Remove qualifying elements from input selectors
- Remove sibling label styles from checkbox and radio inputs
  - Wrapping the `input` with the `label` for `checkbox` & `radio` inputs doesn’t need these styles to align them on a line together
- Fix `select` `multiple` attribute syntax
- Break out overly-DRY selector blocks
  - `label` is a far different item to style than `input`/`select`, which are controls. Combining these in the same declaration causes weird styling workaround when you want to adjust one or the other.
- Add `name` attributes to radio and checkbox inputs
  - These were accidentally removed in a33c5a2
- Remove the insertion of an asterisk for labels with a required class
  - This makes a lot of assumptions, mostly that adding a red asterisk immediately makes it clear that an input is required, which isn’t the case. A more usable and accessible approach should be thought out on a per-project basis.
- Remove non-display of abbr elements inside labels
  - These styles were added with the initial commit of Bitters and I don’t think they are ever used
- Move label declaration block