### PR TITLE
Tweaks

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,5 +1,7 @@
 scss_files: "**/*.scss"
 
+exclude: "node_modules/**"
+
 severity: warning
 
 linters:

--- a/core/_forms.scss
+++ b/core/_forms.scss
@@ -18,7 +18,8 @@ label {
 }
 
 input,
-select {
+select,
+textarea {
   display: block;
   font-family: $base-font-family;
   font-size: $base-font-size;
@@ -31,8 +32,6 @@ select[multiple] {
   border-radius: $base-border-radius;
   box-shadow: $form-box-shadow;
   box-sizing: border-box;
-  font-family: $base-font-family;
-  font-size: $base-font-size;
   margin-bottom: $small-spacing;
   padding: $base-spacing / 3;
   transition: border-color $base-duration $base-timing;

--- a/core/_lists.scss
+++ b/core/_lists.scss
@@ -7,13 +7,13 @@ ol {
 
 dl {
   margin-bottom: $small-spacing;
+}
 
-  dt {
-    font-weight: 600;
-    margin-top: $small-spacing;
-  }
+dt {
+  font-weight: 600;
+  margin-top: $small-spacing;
+}
 
-  dd {
-    margin: 0;
-  }
+dd {
+  margin: 0;
 }

--- a/core/_lists.scss
+++ b/core/_lists.scss
@@ -6,12 +6,12 @@ ol {
 }
 
 dl {
-  margin-bottom: $small-spacing;
+  margin: 0;
 }
 
 dt {
   font-weight: 600;
-  margin-top: $small-spacing;
+  margin: 0;
 }
 
 dd {


### PR DESCRIPTION
- Stop nesting `dt` and `dd` elements (it outputs overly specific selectors for no reason)
- Exclude Node modules from SCSS-Lint
- Clear margins for data list elements
- Consolidate input styles
  - Don't declare font family and size redundantly (currently set both on Line 20, as well as Line 28)
  - Include `textarea` in input styles