### PR TITLE
Update to Bourbon 5

### DIFF
--- a/bitters.gemspec
+++ b/bitters.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
   s.add_development_dependency "scss_lint", "~> 0.44"
-  s.add_runtime_dependency "bourbon", "~> 4.2"
+  s.add_runtime_dependency "bourbon", ">= 5.0.0.beta.1"
   s.add_runtime_dependency "sass", "~> 3.4"
   s.add_runtime_dependency "thor", "~> 0.19"
   s.authors = [

--- a/core/_variables.scss
+++ b/core/_variables.scss
@@ -1,5 +1,5 @@
 // Typography
-$base-font-family: $helvetica;
+$base-font-family: $font-stack-helvetica;
 $heading-font-family: $base-font-family;
 
 // Font Sizes

--- a/core/_variables.scss
+++ b/core/_variables.scss
@@ -1,5 +1,5 @@
 // Typography
-$base-font-family: $font-stack-helvetica;
+$base-font-family: $font-stack-system;
 $heading-font-family: $base-font-family;
 
 // Font Sizes

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "http://bitters.bourbon.io",
   "devDependencies": {
-    "bourbon": "^4.2",
+    "bourbon": "^5.0.0-beta.1",
     "gulp": "^3.9",
     "gulp-autoprefixer": "^3.1",
     "gulp-connect": "^2.3",


### PR DESCRIPTION
- Update Bitters for Bourbon 5 compatibility
- Swap `node-bourbon` for the official `bourbon` package
- Swap Helvetica for system fonts