### PR TITLE
Update Gulp configuration

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,8 +1,8 @@
-var gulp = require("gulp"),
-  autoprefix = require("gulp-autoprefixer"),
-  sass = require("gulp-sass"),
-  connect = require("gulp-connect"),
-  bourbon = require("node-bourbon").includePaths;
+var bourbon    = require("bourbon").includePaths,
+    autoprefix = require("gulp-autoprefixer"),
+    connect    = require("gulp-connect"),
+    gulp       = require("gulp"),
+    sass       = require("gulp-sass");
 
 var paths = {
   scss: [

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "url": "https://github.com/thoughtbot/bitters/issues"
   },
   "homepage": "http://bitters.bourbon.io",
-  "dependencies": {
-    "gulp": "^3.8.11",
-    "gulp-autoprefixer": "^2.3.1",
-    "gulp-connect": "^2.2.0",
-    "gulp-sass": "^2.0.2",
-    "node-bourbon": "^4.2.3"
+  "devDependencies": {
+    "bourbon": "^4.2",
+    "gulp": "^3.9",
+    "gulp-autoprefixer": "^3.1",
+    "gulp-connect": "^2.3",
+    "gulp-sass": "^2.2"
   }
 }


### PR DESCRIPTION
- Update package versions
- Use `devDependencies` instead of `dependencies`
- Swap `node-bourbon` for the official `bourbon` package