### PR TITLE
Increase headings font size

### DIFF
--- a/core/_typography.scss
+++ b/core/_typography.scss
@@ -12,7 +12,7 @@ h4,
 h5,
 h6 {
   font-family: $heading-font-family;
-  font-size: $base-font-size;
+  font-size: modular-scale(1);
   line-height: $heading-line-height;
   margin: 0 0 $small-spacing;
 }


### PR DESCRIPTION
Inspired by Harry Roberts’ post, [_Managing Typography on Large Apps_](http://csswizardry.com/2016/02/managing-typography-on-large-apps/), I think we should slightly increase the font size of all headings.

- All headings (`h1` to `h6`) can still be the same size, which works in a UI context (and what Bitters is built for). UI design doesn’t usually require a _range_ of sizes (which the browser defaults to) like a typographical or content heavy website does.
- HTML heading elements are exactly that, they are headings and most-often this means they should be  a bit higher up the visual hierarchy than other items, hence this change.

<img width="633" alt="screen shot 2016-02-27 at 12 49 10" src="https://cloud.githubusercontent.com/assets/903327/13374370/b37df758-dd50-11e5-8e5a-cab568143fc4.png">