### PR TITLE
Simplify the test

### DIFF
--- a/spec/bitters_spec.rb
+++ b/spec/bitters_spec.rb
@@ -1,17 +1,11 @@
-require 'spec_helper'
-require 'sass'
-require 'bourbon'
+require "sass"
+require "bourbon"
+require "spec_helper"
 
 describe Bitters do
-  after do
-    `rm -rf spec/fixtures/base`
-  end
+  it "compiles to CSS" do
+    Sass.compile_file("spec/fixtures/application.scss", "/tmp/output.css")
 
-  it 'compiles to valid css' do
-    `bitters install --path spec/fixtures`
-
-    Sass.compile_file('spec/fixtures/application.scss', '/tmp/output.css')
-
-    expect(Pathname('/tmp/output.css')).to exist
+    expect(Pathname("/tmp/output.css")).to exist
   end
 end

--- a/spec/fixtures/application.scss
+++ b/spec/fixtures/application.scss
@@ -1,2 +1,2 @@
 @import "bourbon";
-@import "base/base";
+@import "../../core/base";


### PR DESCRIPTION
The test currently runs `bitters install`, which outputs Bitters' Sass files to
compile against, but it's doing so by using whatever local version of Bitters
you have installed, not what is represented in the current state of the repo. So
if you make a breaking change to the Sass, this test will not capture that.

This commit removes the `bitters install` command and instead points directly to
the Sass partials locally within the repo. The test will then try to compile
Bitters' Sass and if it doesn't compile, the test fails.

In the future, we should add more robust tests to specifically test the Bitters
CLI.