### PR TITLE
Fix bitters executable

### DIFF
--- a/bitters.gemspec
+++ b/bitters.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
     extend it to meet your design and brand requirements.
   DESC
   s.email = "design+bitters@thoughtbot.com"
-  s.executables = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  s.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.files = `git ls-files`.split($/)
   s.homepage = "http://bitters.bourbon.io"
   s.license = "MIT"


### PR DESCRIPTION
Currently no executable files are being registered with the gem. This
occurred in e5b61f29ed57e039945b5d91bc9c66faee9c1f73 when the order of the
gemspec configuration was changed. Previously, executables was defined in a
manner in which it depended on `files` being set. This changes `executables` to
be defined via git in a similar fashion to bourbon and neat to remove the
dependency.

Resolves https://github.com/thoughtbot/bitters/issues/228