### PR TITLE
Center align text in buttons

### DIFF
--- a/core/_buttons.scss
+++ b/core/_buttons.scss
@@ -12,6 +12,7 @@
   font-weight: 600;
   line-height: 1;
   padding: $small-spacing $base-spacing;
+  text-align: center;
   text-decoration: none;
   transition: background-color $base-duration $base-timing;
   user-select: none;


### PR DESCRIPTION
When you have buttons that span full-width, it's nice to have the text
within that button be centered, instead of left-aligned.