### PR TITLE
Form styling tweaks

### DIFF
--- a/core/_forms.scss
+++ b/core/_forms.scss
@@ -26,6 +26,7 @@ textarea {
 }
 
 #{$all-text-inputs} {
+  appearance: none;
   background-color: $base-background-color;
   border: $base-border;
   border-radius: $base-border-radius;
@@ -62,10 +63,6 @@ textarea {
 
 textarea {
   resize: vertical;
-}
-
-[type="search"] {
-  appearance: none;
 }
 
 [type="checkbox"],

--- a/core/_forms.scss
+++ b/core/_forms.scss
@@ -81,6 +81,5 @@ textarea {
 
 select {
   margin-bottom: $small-spacing;
-  max-width: 100%;
-  width: auto;
+  width: 100%;
 }

--- a/core/_forms.scss
+++ b/core/_forms.scss
@@ -25,8 +25,7 @@ textarea {
   font-size: $base-font-size;
 }
 
-#{$all-text-inputs},
-select[multiple] {
+#{$all-text-inputs} {
   background-color: $base-background-color;
   border: $base-border;
   border-radius: $base-border-radius;


### PR DESCRIPTION
- Remove styling from `select[multiple]` elements
  - Bundling the styles for `select[multiple]` elements with styles for text-based inputs causes them to render in an unappealing way.
  - It also meant that `select[multiple]` elements would render quite differently than select element elements
- Set select elements to span full-width
  - The horizontal alignment generally can lead to better readability and scanning.
- Remove appearance from all text-based inputs
  - This removes the default inset box shadow that iOS renders on inputs.

### Before

<img src="https://cloud.githubusercontent.com/assets/903327/16248478/6e4e489e-37dd-11e6-9477-2cf9d1624571.jpg" width="350">

### After

<img src="https://cloud.githubusercontent.com/assets/903327/16248475/6c7ed9ac-37dd-11e6-9daa-c82151f4c3ab.jpg" width="350">