### PR TITLE
Declare height on html and body

### DIFF
--- a/core/_layout.scss
+++ b/core/_layout.scss
@@ -7,3 +7,8 @@ html {
 *::after {
   box-sizing: inherit;
 }
+
+html,
+body {
+  height: 100%;
+}


### PR DESCRIPTION
This stretches the `html` and `body` elements to always be full height
within the viewport. It allows children to then also stretch the full
height of the viewport.

I think it aligns with most people's expected behavior.