### PR TITLE
Remove named color variable input placeholder styles

### DIFF
--- a/core/_forms.scss
+++ b/core/_forms.scss
@@ -57,7 +57,7 @@ textarea {
   }
 
   &::placeholder {
-    color: $medium-gray;
+    color: tint($base-font-color, 40%);
   }
 }
 


### PR DESCRIPTION
As noted by @cappadonia, https://github.com/thoughtbot/bitters/pull/242 introduced a named color variable `$medium-gray` outside of the variables file. Issue: https://github.com/thoughtbot/bitters/issues/256

**Note**: Placeholder now renders as `#858585` as apposed to `#999`
