### PR TITLE
Expanded variable spacing system

### DIFF
--- a/contrib/styles.scss
+++ b/contrib/styles.scss
@@ -2,18 +2,18 @@
 @import "../core/base";
 
 body {
-  margin: 0 0 ($base-spacing * 2);
+  margin: 0 0 $space-l;
 }
 
 .container {
   @include margin(null auto);
-  @include padding(null $base-spacing);
+  @include padding(null $space-m);
   max-width: 500px;
 }
 
 .welcome-message {
-  @include padding($base-spacing null);
+  @include padding($space-m null);
   background-color: #f2f2f2;
-  margin-bottom: $base-spacing;
+  margin-bottom: $space-m;
   text-align: center;
 }

--- a/contrib/styles.scss
+++ b/contrib/styles.scss
@@ -2,18 +2,18 @@
 @import "../core/base";
 
 body {
-  margin: 0 0 $space-l;
+  margin: 0 0 $space-large;
 }
 
 .container {
   @include margin(null auto);
-  @include padding(null $space-m);
+  @include padding(null $space-medium);
   max-width: 500px;
 }
 
 .welcome-message {
-  @include padding($space-m null);
+  @include padding($space-medium null);
   background-color: #f2f2f2;
-  margin-bottom: $space-m;
+  margin-bottom: $space-medium;
   text-align: center;
 }

--- a/core/_buttons.scss
+++ b/core/_buttons.scss
@@ -11,7 +11,7 @@
   -webkit-font-smoothing: antialiased;
   font-weight: 600;
   line-height: 1;
-  padding: $small-spacing $base-spacing;
+  padding: $space-s $space-m;
   text-align: center;
   text-decoration: none;
   transition: background-color $base-duration $base-timing;

--- a/core/_buttons.scss
+++ b/core/_buttons.scss
@@ -11,7 +11,7 @@
   -webkit-font-smoothing: antialiased;
   font-weight: 600;
   line-height: 1;
-  padding: $space-s $space-m;
+  padding: $space-small $space-medium;
   text-align: center;
   text-decoration: none;
   transition: background-color $base-duration $base-timing;

--- a/core/_forms.scss
+++ b/core/_forms.scss
@@ -7,14 +7,14 @@ fieldset {
 
 legend {
   font-weight: 600;
-  margin-bottom: $space-xs;
+  margin-bottom: $space-x-small;
   padding: 0;
 }
 
 label {
   display: block;
   font-weight: 600;
-  margin-bottom: $space-xs;
+  margin-bottom: $space-x-small;
 }
 
 input,
@@ -32,8 +32,8 @@ textarea {
   border-radius: $base-border-radius;
   box-shadow: $form-box-shadow;
   box-sizing: border-box;
-  margin-bottom: $space-s;
-  padding: $space-xs;
+  margin-bottom: $space-small;
+  padding: $space-x-small;
   transition: border-color $base-duration $base-timing;
   width: 100%;
 
@@ -68,15 +68,15 @@ textarea {
 [type="checkbox"],
 [type="radio"] {
   display: inline;
-  margin-right: $space-xs;
+  margin-right: $space-x-small;
 }
 
 [type="file"] {
-  margin-bottom: $space-s;
+  margin-bottom: $space-small;
   width: 100%;
 }
 
 select {
-  margin-bottom: $space-s;
+  margin-bottom: $space-small;
   width: 100%;
 }

--- a/core/_forms.scss
+++ b/core/_forms.scss
@@ -7,14 +7,14 @@ fieldset {
 
 legend {
   font-weight: 600;
-  margin-bottom: $small-spacing / 2;
+  margin-bottom: $space-xs;
   padding: 0;
 }
 
 label {
   display: block;
   font-weight: 600;
-  margin-bottom: $small-spacing / 2;
+  margin-bottom: $space-xs;
 }
 
 input,
@@ -32,8 +32,8 @@ textarea {
   border-radius: $base-border-radius;
   box-shadow: $form-box-shadow;
   box-sizing: border-box;
-  margin-bottom: $small-spacing;
-  padding: $base-spacing / 3;
+  margin-bottom: $space-s;
+  padding: $space-xs;
   transition: border-color $base-duration $base-timing;
   width: 100%;
 
@@ -68,15 +68,15 @@ textarea {
 [type="checkbox"],
 [type="radio"] {
   display: inline;
-  margin-right: $small-spacing / 2;
+  margin-right: $space-xs;
 }
 
 [type="file"] {
-  margin-bottom: $small-spacing;
+  margin-bottom: $space-s;
   width: 100%;
 }
 
 select {
-  margin-bottom: $small-spacing;
+  margin-bottom: $space-s;
   width: 100%;
 }

--- a/core/_tables.scss
+++ b/core/_tables.scss
@@ -1,6 +1,6 @@
 table {
   border-collapse: collapse;
-  margin: $space-s 0;
+  margin: $space-small 0;
   table-layout: fixed;
   width: 100%;
 }
@@ -8,13 +8,13 @@ table {
 th {
   border-bottom: 1px solid shade($base-border-color, 25%);
   font-weight: 600;
-  padding: $space-s 0;
+  padding: $space-small 0;
   text-align: left;
 }
 
 td {
   border-bottom: $base-border;
-  padding: $space-s 0;
+  padding: $space-small 0;
 }
 
 tr,

--- a/core/_tables.scss
+++ b/core/_tables.scss
@@ -1,6 +1,6 @@
 table {
   border-collapse: collapse;
-  margin: $small-spacing 0;
+  margin: $space-s 0;
   table-layout: fixed;
   width: 100%;
 }
@@ -8,13 +8,13 @@ table {
 th {
   border-bottom: 1px solid shade($base-border-color, 25%);
   font-weight: 600;
-  padding: $small-spacing 0;
+  padding: $space-s 0;
   text-align: left;
 }
 
 td {
   border-bottom: $base-border;
-  padding: $small-spacing 0;
+  padding: $space-s 0;
 }
 
 tr,

--- a/core/_typography.scss
+++ b/core/_typography.scss
@@ -14,11 +14,11 @@ h6 {
   font-family: $heading-font-family;
   font-size: modular-scale(1);
   line-height: $heading-line-height;
-  margin: 0 0 $space-s;
+  margin: 0 0 $space-small;
 }
 
 p {
-  margin: 0 0 $space-s;
+  margin: 0 0 $space-small;
 }
 
 a {
@@ -38,5 +38,5 @@ hr {
   border-left: 0;
   border-right: 0;
   border-top: 0;
-  margin: $space-m 0;
+  margin: $space-medium 0;
 }

--- a/core/_typography.scss
+++ b/core/_typography.scss
@@ -14,11 +14,11 @@ h6 {
   font-family: $heading-font-family;
   font-size: modular-scale(1);
   line-height: $heading-line-height;
-  margin: 0 0 $small-spacing;
+  margin: 0 0 $space-s;
 }
 
 p {
-  margin: 0 0 $small-spacing;
+  margin: 0 0 $space-s;
 }
 
 a {
@@ -38,5 +38,5 @@ hr {
   border-left: 0;
   border-right: 0;
   border-top: 0;
-  margin: $base-spacing 0;
+  margin: $space-m 0;
 }

--- a/core/_variables.scss
+++ b/core/_variables.scss
@@ -14,9 +14,13 @@ $base-line-height: 1.5;
 $heading-line-height: 1.2;
 
 // Other Sizes
+$space-xs: 0.5em;
+$space-s: 0.75em;
+$space-m: 1.5em;
+$space-l: 3em;
+$space-xl: 4.5em;
+
 $base-border-radius: 3px;
-$base-spacing: $base-line-height * 1em;
-$small-spacing: $base-spacing / 2;
 $base-z-index: 0;
 
 // Colors

--- a/core/_variables.scss
+++ b/core/_variables.scss
@@ -13,13 +13,14 @@ $base-font-size: 1em;
 $base-line-height: 1.5;
 $heading-line-height: 1.2;
 
-// Other Sizes
-$space-xs: 0.5em;
-$space-s: 0.75em;
-$space-m: 1.5em;
-$space-l: 3em;
-$space-xl: 4.5em;
+// Spacing
+$space-x-small: 0.5em;
+$space-small: 0.75em;
+$space-medium: 1.5em;
+$space-large: 3em;
+$space-x-large: 4.5em;
 
+// Other Sizes
 $base-border-radius: 3px;
 $base-z-index: 0;
 


### PR DESCRIPTION
This is a work-in-progress, I’m looking for feedback.

This PR replaces `$base-spacing` and `$small-spacing` with a series of t-shirt-size-based variables that create a more holistic, flexible system.

Why? A few reasons:

1. Many times over, I see wild calculations built upon `$base-spacing`, e.g. `$base-spacing * 1.2`. It’s great that we are using a common base here, but the `y` in this equation is pulled out of thin air and means that we no longer have a _series_ of related values.
2. `base-` and `small-` breaks down when you need a system. A t-shirt size scale is easily recognizable, memorable, expandable and succinct.
3. With a series of variables pre-set (and their values can/should be changed by authors), it means we can more easily review PR’s. If we see `$space-m * 1.2`, it means our design system is failing us and we should aim to fix the wider system, not introduce exclusive, calculated values.

I really like how Nathan Curtis broke this down in [Space in Design Systems](https://medium.com/eightshapes-llc/space-in-design-systems-188bcbae0d62#.9n78vka6c) and this PR is inspired by his work.

The changes here _do not_ change the current length values. Meaning, I made `$space-m` the same value as `$base-spacing`. I see this as a first step and to not completely change the scale all at once.