### PR TITLE
Add styles for `small`

### DIFF
--- a/contrib/index.html
+++ b/contrib/index.html
@@ -42,9 +42,9 @@
         Lorem ipsum dolor sit amet, <em>emphasis</em> consectetuer adipiscing
         elit. Nullam dignissim convallis est. Quisque aliquam. Donec faucibus.
         Nunc iaculis <strong>strong</strong> dui. Nam sit amet sem. Aliquam libero nisi,
-        imperdiet at, tincidunt nec, gravida vehicula, nisl. Praesent mattis,
+        imperdiet at, tincidunt nec, gravida vehicula, nisl. <small>Praesent mattis,
         massa quis luctus fermentum, turpis mi volutpat justo, eu volutpat enim
-        diam eget metus. Maecenas ornare tortor. Donec sed tellus eget sapien
+        diam eget metus.</small> Maecenas ornare tortor. Donec sed tellus eget sapien
         fringilla nonummy. Mauris a ante. Suspendisse quam sem, consequat at,
         commodo vitae, feugiat in, nunc. Morbi imperdiet augue quis tellus.
       </p>

--- a/core/_typography.scss
+++ b/core/_typography.scss
@@ -40,3 +40,7 @@ hr {
   border-top: 0;
   margin: $base-spacing 0;
 }
+
+small {
+  font-size: modular-scale(-1);
+}


### PR DESCRIPTION
The browser defaults for `small` is difficult to discern from other text.
This change utilizes `modular-scale` to set `small` font size.

<img width="842" alt="screenshot 2016-12-19 15 15 55" src="https://cloud.githubusercontent.com/assets/2489247/21327702/68b9429e-c5fe-11e6-840a-9de97fa2f8cd.png">
