### PR TITLE
Move spacing variable to `space()` function.

### DIFF
--- a/contrib/styles.scss
+++ b/contrib/styles.scss
@@ -2,18 +2,18 @@
 @import "../core/base";
 
 body {
-  margin: 0 0 ($base-spacing * 2);
+  margin: 0 0 space(4);
 }
 
 .container {
   @include margin(null auto);
-  @include padding(null $base-spacing);
+  @include padding(null space(0));
   max-width: 500px;
 }
 
 .welcome-message {
-  @include padding($base-spacing null);
+  @include padding(space(0) null);
   background-color: #f2f2f2;
-  margin-bottom: $base-spacing;
+  margin-bottom: space(0);
   text-align: center;
 }

--- a/core/_buttons.scss
+++ b/core/_buttons.scss
@@ -11,7 +11,7 @@
   -webkit-font-smoothing: antialiased;
   font-weight: 600;
   line-height: 1;
-  padding: $small-spacing $base-spacing;
+  padding: space(-2) space(0);
   text-align: center;
   text-decoration: none;
   transition: background-color $base-duration $base-timing;

--- a/core/_forms.scss
+++ b/core/_forms.scss
@@ -7,14 +7,14 @@ fieldset {
 
 legend {
   font-weight: 600;
-  margin-bottom: $small-spacing / 2;
+  margin-bottom: space(-2);
   padding: 0;
 }
 
 label {
   display: block;
   font-weight: 600;
-  margin-bottom: $small-spacing / 2;
+  margin-bottom: space(-2);
 }
 
 input,
@@ -32,8 +32,8 @@ textarea {
   border-radius: $base-border-radius;
   box-shadow: $form-box-shadow;
   box-sizing: border-box;
-  margin-bottom: $small-spacing;
-  padding: $base-spacing / 3;
+  margin-bottom: space(-2);
+  padding: space(-4);
   transition: border-color $base-duration $base-timing;
   width: 100%;
 
@@ -68,15 +68,15 @@ textarea {
 [type="checkbox"],
 [type="radio"] {
   display: inline;
-  margin-right: $small-spacing / 2;
+  margin-right: space(-4);
 }
 
 [type="file"] {
-  margin-bottom: $small-spacing;
+  margin-bottom: space(-2);
   width: 100%;
 }
 
 select {
-  margin-bottom: $small-spacing;
+  margin-bottom: space(-2);
   width: 100%;
 }

--- a/core/_tables.scss
+++ b/core/_tables.scss
@@ -1,6 +1,6 @@
 table {
   border-collapse: collapse;
-  margin: $small-spacing 0;
+  margin: space(-2) 0;
   table-layout: fixed;
   width: 100%;
 }
@@ -8,13 +8,13 @@ table {
 th {
   border-bottom: 1px solid shade($base-border-color, 25%);
   font-weight: 600;
-  padding: $small-spacing 0;
+  padding: space(-3) 0;
   text-align: left;
 }
 
 td {
   border-bottom: $base-border;
-  padding: $small-spacing 0;
+  padding: space(-3) 0;
 }
 
 tr,

--- a/core/_typography.scss
+++ b/core/_typography.scss
@@ -14,11 +14,11 @@ h6 {
   font-family: $heading-font-family;
   font-size: modular-scale(1);
   line-height: $heading-line-height;
-  margin: 0 0 $small-spacing;
+  margin: 0 0 space(-2);
 }
 
 p {
-  margin: 0 0 $small-spacing;
+  margin: 0 0 space(-2);
 }
 
 a {
@@ -38,5 +38,5 @@ hr {
   border-left: 0;
   border-right: 0;
   border-top: 0;
-  margin: $base-spacing 0;
+  margin: space(0) 0;
 }

--- a/core/_variables.scss
+++ b/core/_variables.scss
@@ -13,10 +13,14 @@ $base-font-size: 1em;
 $base-line-height: 1.5;
 $heading-line-height: 1.2;
 
+// Spacing
+@function space($factor) {
+  $factor: strip-unit(modular-scale($factor));
+  @return ($factor * $base-line-height * 1rem);
+}
+
 // Other Sizes
 $base-border-radius: 3px;
-$base-spacing: $base-line-height * 1em;
-$small-spacing: $base-spacing / 2;
 $base-z-index: 0;
 
 // Colors


### PR DESCRIPTION
Traditionally we have had spacing handled by a series of variables, i.e. `$base-spacing`. This change adds the `space()` function.

This function uses the Bourbon `modular-scale()` function to create a series of values based on the global modular scale multiplied by the `$base-line-height`, returning a `rem` value. This change allows for a high level of spacing granularity while maintaining a simple and scaleable approach, without polluting the global variable namespace.

---

![screencapture-localhost-8000-1482249989413](https://cloud.githubusercontent.com/assets/2489247/21358045/7b6a00c0-c6a5-11e6-8116-dd6c36850228.png)
