### PR TITLE
Remove `$base-font-size` variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,13 @@ project adheres to [Semantic Versioning](http://semver.org).
 - Base typography is now styled off of the `html` element, instead of the `body`
   element. ([#279])
 
+### Removed
+
+- Removed `$base-font-size` in favor of more specific implimentations specific
+  to the particular object being modified. ([#272])
+
 [Unreleased]: https://github.com/thoughtbot/bitters/compare/v1.5.0...HEAD
+[#272]: https://github.com/thoughtbot/bitters/pull/272
 [#275]: https://github.com/thoughtbot/bitters/pull/275
 [#279]: https://github.com/thoughtbot/bitters/pull/279
 [#280]: https://github.com/thoughtbot/bitters/pull/280

--- a/core/_buttons.scss
+++ b/core/_buttons.scss
@@ -7,7 +7,7 @@
   cursor: pointer;
   display: inline-block;
   font-family: $base-font-family;
-  font-size: $base-font-size;
+  font-size: 16px;
   -webkit-font-smoothing: antialiased;
   font-weight: 600;
   line-height: 1;

--- a/core/_forms.scss
+++ b/core/_forms.scss
@@ -25,7 +25,7 @@ select,
 textarea {
   display: block;
   font-family: $base-font-family;
-  font-size: $base-font-size;
+  font-size: 16px;
 }
 
 #{$all-text-inputs} {

--- a/core/_typography.scss
+++ b/core/_typography.scss
@@ -1,7 +1,7 @@
 html {
   color: $base-font-color;
   font-family: $base-font-family;
-  font-size: $base-font-size;
+  font-size: 100%;
   line-height: $base-line-height;
 }
 

--- a/core/_variables.scss
+++ b/core/_variables.scss
@@ -6,9 +6,6 @@ $large-screen: 900px;
 $base-font-family: $font-stack-system;
 $heading-font-family: $base-font-family;
 
-// Font Sizes
-$base-font-size: 1em;
-
 // Line height
 $base-line-height: 1.5;
 $heading-line-height: 1.2;


### PR DESCRIPTION
`$base-font-size` feels a bit legacy to me since we are already using `modular-scale()`, especially, the defined behavior is to output 1em (aka modular-scale-base). 

no visual change.