### PR TITLE
Style base typography off of html instead of body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,13 @@ project adheres to [Semantic Versioning](http://semver.org).
   partials, rather than in the global variables partial. They have also been
   prefixed with an underscore to indicate they are "private" to that
   partial. ([#275])
+- Base typography is now styled off of the `html` element, instead of the `body`
+  element. ([#279])
 
 [Unreleased]: https://github.com/thoughtbot/bitters/compare/v1.5.0...HEAD
+[#275]: https://github.com/thoughtbot/bitters/pull/275
+[#279]: https://github.com/thoughtbot/bitters/pull/279
 [#280]: https://github.com/thoughtbot/bitters/pull/280
-[#275]: https://github.com/thoughtbot/bitters/pull/275/
 
 ## [1.5.0] - 2016-11-08
 

--- a/core/_typography.scss
+++ b/core/_typography.scss
@@ -1,4 +1,4 @@
-body {
+html {
   color: $base-font-color;
   font-family: $base-font-family;
   font-size: $base-font-size;


### PR DESCRIPTION
Because `rem` units calculate their value off of the root element
(`html`), setting our base font size on the `html` element instead of
the `body` element means that we can adjust the global font size and all
relative units will follow.

Here’s an example:

I have a component, sized in rems…

```css
.component {
  padding: 1rem;
}
```

Currently, if I adjust Bitters’ base font size from `1em` to `2em`, my expectation would be for the padding above to then equate to `2em`/`32px`. But since we are setting this base font size on `body` and not `html`, this isn’t true and that padding will still equal `1em`/`16px`.