### PR TITLE
Remove margin from body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased]
 
+### Added
+
+- Set `margin` to `0` on the `body` element. ([#280])
+
 ### Changed
 
 - Component/feature-specific variables have been moved into their respective
@@ -13,6 +17,7 @@ project adheres to [Semantic Versioning](http://semver.org).
   partial. ([#275])
 
 [Unreleased]: https://github.com/thoughtbot/bitters/compare/v1.5.0...HEAD
+[#280]: https://github.com/thoughtbot/bitters/pull/280
 [#275]: https://github.com/thoughtbot/bitters/pull/275/
 
 ## [1.5.0] - 2016-11-08

--- a/core/_layout.scss
+++ b/core/_layout.scss
@@ -12,3 +12,7 @@ html,
 body {
   height: 100%;
 }
+
+body {
+  margin: 0;
+}


### PR DESCRIPTION
normalize.css <6.0.0 set the `margin` to `0` on `body`. normalize 6.0.0
removed this, along with other opinionated rules.

See: https://github.com/necolas/normalize.css/commit/b5f0e9d79a997952f0d68f55c12ec3b76dd65882