### PR TITLE
Remove disabling of link text decoration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ project adheres to [Semantic Versioning](http://semver.org).
   partial. ([#275])
 - Base typography is now styled off of the `html` element, instead of the `body`
   element. ([#279])
+- `a` elements no longer have `text-decoration` set to `none`. They also now
+  have `text-decoration-skip` set to `ink`. ([#283])
 
 ### Removed
 
@@ -28,6 +30,7 @@ project adheres to [Semantic Versioning](http://semver.org).
 [#275]: https://github.com/thoughtbot/bitters/pull/275
 [#279]: https://github.com/thoughtbot/bitters/pull/279
 [#280]: https://github.com/thoughtbot/bitters/pull/280
+[#283]: https://github.com/thoughtbot/bitters/pull/283
 
 ## [1.5.0] - 2016-11-08
 

--- a/contrib/index.html
+++ b/contrib/index.html
@@ -28,8 +28,8 @@
       <h5>Heading 5</h5>
       <h6>Heading 6</h6>
       <p>
-        Lorem ipsum dolor sit amet, <a href="#" title="test link">test link</a>
-        adipiscing elit. Nullam dignissim convallis est. Quisque aliquam. Donec
+        Lorem ipsum dolor sit amet, <a href="#">test link adipiscing elit</a>.
+        Nullam dignissim convallis est. Quisque aliquam. Donec
         faucibus. Nunc iaculis suscipit dui. Nam sit amet sem. Aliquam libero
         nisi, imperdiet at, tincidunt nec, gravida vehicula, nisl. Praesent
         mattis, massa quis luctus fermentum, turpis mi volutpat justo, eu

--- a/core/_typography.scss
+++ b/core/_typography.scss
@@ -23,7 +23,7 @@ p {
 
 a {
   color: $action-color;
-  text-decoration: none;
+  text-decoration-skip: ink;
   transition: color $base-duration $base-timing;
 
   &:active,


### PR DESCRIPTION
Styling links only through color and removing their default underline
is an accessibility concern for people with color blindness. It's
possible they would not be able to discern the difference between
regular text and a link.

This commit also sets the `text-decoration-skip` property to `ink` for
all links, which only draws text decoration where it does not touch or
closely approach a glyph.

`text-decoration-skip` is support in most browsers with a prefix, excluding IE & Edge: http://caniuse.com/#feat=text-decoration

---

<img width="790" alt="screen shot 2017-04-22 at 13 29 21" src="https://cloud.githubusercontent.com/assets/903327/25306663/c886597e-275f-11e7-85a9-d7c31dfb4824.png">
