### PR TITLE
Improve table layout

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -160,7 +160,6 @@ linters:
 
   Shorthand:
     enabled: true
-    allowed_shorthands: [1, 2, 3]
 
   SingleLinePerProperty:
     enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,20 @@ project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased]
 
+### Changed
+
+- `table` styles have been improved with left text-alignment throughout the
+  whole table, bottom vertical-alignment within the `thead`, top
+  vertical-alignment within the `tbody`, right padding within each cell and
+  borders being set on the `tr`s. ([#288])
+
 ### Removed
 
 - Remove unused `$medium-screen` and `$large-screen` breakpoint
   variables. ([#285])
 
 [#285]: https://github.com/thoughtbot/bitters/pull/285
+[#288]: https://github.com/thoughtbot/bitters/pull/288
 
 ## [1.6.0] - 2017-05-12
 

--- a/contrib/index.html
+++ b/contrib/index.html
@@ -138,26 +138,33 @@
       </form>
       <hr>
       <table>
-        <tr>
-          <th>Table Header 1</th>
-          <th>Table Header 2</th>
-          <th>Table Header 3</th>
-        </tr>
-        <tr>
-          <td>Division 1</td>
-          <td>Division 2</td>
-          <td>Division 3</td>
-        </tr>
-        <tr>
-          <td>Division 1</td>
-          <td>Division 2</td>
-          <td>Division 3</td>
-        </tr>
-        <tr>
-          <td>Division 1</td>
-          <td>Division 2</td>
-          <td>Division 3</td>
-        </tr>
+        <thead>
+          <tr>
+            <th>Table Header 1</th>
+            <th>Table Header 2 Which is Very Long</th>
+            <th>Table Header 3</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Division 1</td>
+            <td>Division 2</td>
+            <td>Division 3</td>
+          </tr>
+          <tr>
+            <td>Division 1</td>
+            <td>Division 2</td>
+            <td>Division 3 with some long text</td>
+          </tr>
+          <tr>
+            <td>Division 1</td>
+            <td>
+              Division 2 with some even longer text that seems to just ramble on
+              and on&hellip;
+            </td>
+            <td>Division 3</td>
+          </tr>
+        </tbody>
       </table>
     </main>
   </body>

--- a/core/_tables.scss
+++ b/core/_tables.scss
@@ -1,24 +1,29 @@
 table {
   border-collapse: collapse;
-  margin: $small-spacing 0;
+  margin: $base-spacing 0;
   table-layout: fixed;
+  text-align: left;
   width: 100%;
 }
 
-th {
-  border-bottom: 1px solid shade($base-border-color, 25%);
-  font-weight: 600;
-  padding: $small-spacing 0;
-  text-align: left;
+thead {
+  line-height: $heading-line-height;
+  vertical-align: bottom;
 }
 
-td {
+tbody {
+  vertical-align: top;
+}
+
+tr {
   border-bottom: $base-border;
-  padding: $small-spacing 0;
 }
 
-tr,
-td,
 th {
-  vertical-align: middle;
+  font-weight: 600;
+}
+
+th,
+td {
+  padding: $small-spacing $small-spacing $small-spacing 0;
 }


### PR DESCRIPTION
I’ve been working on a few table-heavy projects lately and I’ve found that the base table styles that Bitters provided me left a lot to be desired. Specifically, if the table has decently long strings of text within it, the layout really fell apart and made for a painful reading experience. This PR updates the table styles with a new niceties which I think makes a great starting point for nearly all tables, and also updates the contributing page markup to include some longer text within the cells.

- Increase bottom and top margin on tables
  - This matches the same bottom and top margin values we set on `hr` elements.
- Move `text-align` property to `table`
  - In most situations, left-aligned text within a table is ideal. This makes sure the whole table is left-aligned, while still allowing easy overriding on a per-column basis (e.g. for numeral data).
- Change vertical alignment of tables
  - Vertically aligning cell text in the middle makes for a bad reading experience because there is no consistent or expected starting point for text that the eyes can pick up on.
  - This changes the vertical alignment of cell text to:
    - Bottom of the cell in the table header (`thead`)
    - Top of the cell in the table body (`tbody`)
- Set table borders on the row
  - Rather than setting borders on each individual cell, this sets it on the whole row (`tr`).
- Use the headings line-height in table headers
- Add padding to the right of each table cell
  - This prevents adjacement cell text from butting into each other.

## Before

![screen shot 2017-05-25 at 10 32 55](https://cloud.githubusercontent.com/assets/903327/26454784/144626ba-4136-11e7-8dfa-5d2db26acbd1.png)

## After

![screen shot 2017-05-25 at 10 33 15](https://cloud.githubusercontent.com/assets/903327/26454787/17bbded4-4136-11e7-8ef9-8b9ca2b31542.png)