### PR TITLE
Remove Sache

### DIFF
--- a/sache.json
+++ b/sache.json
@@ -1,5 +1,0 @@
-{
-  "name": "Bitters",
-  "description": "Scaffold styles, variables and structure for Bourbon projects",
-  "tags": ["buttons", "forms", "structure", "typography", "variables"]
-}


### PR DESCRIPTION
We’ve removed this from both Bourbon and Neat. The project also seems a bit dead, given that [their last tweet was in 2015](https://twitter.com/sache_in).