### PR TITLE
Disconnect $base-spacing from $base-line-height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ project adheres to [Semantic Versioning](http://semver.org).
   whole table, bottom vertical-alignment within the `thead`, top
   vertical-alignment within the `tbody`, right padding within each cell and
   borders being set on the `tr`s. ([#288])
+- The value of `$base-spacing` is no longer derived from `$base-line-height`.
+  ([#292])
 
 ### Removed
 
@@ -20,6 +22,7 @@ project adheres to [Semantic Versioning](http://semver.org).
 [Unreleased]: https://github.com/thoughtbot/bitters/compare/v1.6.0...HEAD
 [#285]: https://github.com/thoughtbot/bitters/pull/285
 [#288]: https://github.com/thoughtbot/bitters/pull/288
+[#292]: https://github.com/thoughtbot/bitters/pull/292
 
 ## [1.6.0] - 2017-05-12
 

--- a/core/_variables.scss
+++ b/core/_variables.scss
@@ -8,7 +8,7 @@ $heading-line-height: 1.2;
 
 // Other Sizes
 $base-border-radius: 3px;
-$base-spacing: $base-line-height * 1em;
+$base-spacing: 1.5em;
 $small-spacing: $base-spacing / 2;
 $base-z-index: 0;
 


### PR DESCRIPTION
The two serve different purposes and their values don't need to be
relational. Also, since we do not facilitate or support a vertical
rhythm, the two variables do not need to be connected.

One situation where I've found this to be problematic (when they are
connected) is when I want to tweak the line height for a specific
typeface, but I don't want that change to manipulate spacing throughout
the whole application.