### PR TITLE
Refactor background color variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,25 @@ project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased (`master`)][unreleased]
 
-Nothing at the moment.
+### Added
+
+- Added `$_form-background-color` for setting the `background-color` of text
+  inputs. ([#296])
+
+### Changed
+
+- Form text inputs now use `$_form-background-color` instead of
+  `$base-background-color` as their `background-color`. ([#296])
+- `$base-background-color` is now `$viewport-background-color` and is used to
+  set the `background-color` of the `html` element. ([#296])
+
+### Removed
+
+- `$secondary-background-color` has been removed (it was not used for setting
+  any values. ([#296])
 
 [unreleased]: https://github.com/thoughtbot/bitters/compare/v1.7.0...HEAD
+[#296]: https://github.com/thoughtbot/bitters/pull/296
 
 ## [1.7.0] - 2017-06-30
 

--- a/core/_forms.scss
+++ b/core/_forms.scss
@@ -1,3 +1,4 @@
+$_form-background-color: #fff;
 $_form-box-shadow: inset 0 1px 3px rgba(#000, 0.06);
 $_form-box-shadow-focus: $_form-box-shadow, 0 0 5px rgba($action-color, 0.7);
 
@@ -30,7 +31,7 @@ textarea {
 
 #{$all-text-inputs} {
   appearance: none;
-  background-color: $base-background-color;
+  background-color: $_form-background-color;
   border: $base-border;
   border-radius: $base-border-radius;
   box-shadow: $_form-box-shadow;
@@ -51,7 +52,7 @@ textarea {
   }
 
   &:disabled {
-    background-color: shade($base-background-color, 5%);
+    background-color: shade($_form-background-color, 5%);
     cursor: not-allowed;
 
     &:hover {

--- a/core/_layout.scss
+++ b/core/_layout.scss
@@ -1,4 +1,5 @@
 html {
+  background-color: $viewport-background-color;
   box-sizing: border-box;
 }
 

--- a/core/_variables.scss
+++ b/core/_variables.scss
@@ -27,8 +27,7 @@ $base-border-color: $light-gray;
 $base-border: 1px solid $base-border-color;
 
 // Background Colors
-$base-background-color: #fff;
-$secondary-background-color: tint($base-border-color, 75%);
+$viewport-background-color: #fff;
 
 // Focus
 $focus-outline-color: transparentize($action-color, 0.4);


### PR DESCRIPTION
`$base-background-color` is only used for setting the background color
of form inputs. That variable name doesn't make sense in that context;
it makes it seem as though you can set this variable and change the
background color of the viewport.

This change swaps the name of `$base-background-color` to
`$viewport-background-color` and sets it as a value on the `html`
element. It also removes the `$secondary-background-color` variable,
which is not used at all.

Finally, a specific and private `$_form-background-color` variable is
added to set the background color on form inputs.