### PR TITLE
Override CircleCI's dependencies command

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,9 @@ general:
   branches:
     ignore:
       - gh-pages
+dependencies:
+  override:
+    - bundle install
 test:
   override:
     - bundle exec rake


### PR DESCRIPTION
CircleCI was inferring that `npm install` needed to be ran for project
dependencies. This isn't case, as the Node dependencies are only used
for spinning up a local development instance, not for tests.

Running `npm install` was causing a failing build due to some issues
in the packages: https://circleci.com/gh/thoughtbot/bitters/161

This change manually overrides CircleCI's inference, by telling it to
only install the needed Ruby dependencies for testing.

Circle docs: https://circleci.com/docs/1.0/configuration/
Failed