### PR TITLE
Change project SASS variables to native CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased (`master`)][unreleased]
 
-Nothing at the moment.
+### Changed
+
+- Changed project Sass variables to native CSS variables
+- Added variables for all font weights
+
+### Removed
+
+- Removed unused `base-z-index` variable
+- Removed unused `medium-gray` variable
 
 [unreleased]: https://github.com/thoughtbot/bitters/compare/v1.8.0...HEAD
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,17 @@ project adheres to [Semantic Versioning](http://semver.org).
 ## [Unreleased (`master`)][unreleased]
 
 ### Added
+
 - Added variables for all font weights
 
 ### Changed
 
 - Changed project Sass variables to native CSS variables
+- Changed variables name structures:
+  - Remove "`base`" from CSS vars (`--base-font-family` to `--font-family`)
+  - Placing the modifier after the noun instead of before. Example: `--font-family--heading`
+  - Separating the modifier and noun with 2 dashes. Example: `--font-weight--extra-light`
+- Changed the default border to use `currentColor`
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased (`master`)][unreleased]
 
+### Added
+- Added variables for all font weights
+
 ### Changed
 
 - Changed project Sass variables to native CSS variables
-- Added variables for all font weights
 
 ### Removed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ Some things that will increase the chance that your pull request is accepted:
 * Two spaces, no tabs.
 * Dashes instead of underscores or camel case: `section-header` **not**
   `section_header` or `sectionHeader`
-* Names should be descriptive and written in full-words: `$base-font-color`
+* Names should be descriptive and written in full-words: `$font-color--base`
   **not** `$color` or `$txtCLR`
 * Space between property and value: `width: 20px` **not** `width:20px`
 * Declarations within a block should be ordered alphabetically.

--- a/contrib/styles.scss
+++ b/contrib/styles.scss
@@ -2,18 +2,18 @@
 @import "../core/base";
 
 body {
-  margin: 0 0 calc(var(--base-spacing) * 2);
+  margin: 0 0 calc(var(--spacing) * 2);
 }
 
 .container {
   @include margin(null auto);
-  @include padding(null var(--base-spacing));
+  @include padding(null var(--spacing));
   max-width: 500px;
 }
 
 .welcome-message {
-  @include padding(var(--base-spacing) null);
+  @include padding(var(--spacing) null);
   background-color: #f2f2f2;
-  margin-bottom: var(--base-spacing);
+  margin-bottom: var(--spacing);
   text-align: center;
 }

--- a/contrib/styles.scss
+++ b/contrib/styles.scss
@@ -2,18 +2,18 @@
 @import "../core/base";
 
 body {
-  margin: 0 0 ($base-spacing * 2);
+  margin: 0 0 calc(var(--base-spacing) * 2);
 }
 
 .container {
   @include margin(null auto);
-  @include padding(null $base-spacing);
+  @include padding(null var(--base-spacing));
   max-width: 500px;
 }
 
 .welcome-message {
-  @include padding($base-spacing null);
+  @include padding(var(--base-spacing) null);
   background-color: #f2f2f2;
-  margin-bottom: $base-spacing;
+  margin-bottom: var(--base-spacing);
   text-align: center;
 }

--- a/core/_buttons.scss
+++ b/core/_buttons.scss
@@ -19,6 +19,10 @@
   vertical-align: middle;
   white-space: nowrap;
 
+  &:hover {
+    background-color: var(--action-color-alt);
+  }
+
   &:focus {
     outline: var(--focus-outline);
     outline-offset: var(--focus-outline-offset);

--- a/core/_buttons.scss
+++ b/core/_buttons.scss
@@ -1,6 +1,6 @@
 #{$all-buttons} {
   appearance: none;
-  background-color: var(--action-color);
+  background-color: $action-color;
   border: 0;
   border-radius: var(--base-border-radius);
   color: inherit;
@@ -20,7 +20,7 @@
   white-space: nowrap;
 
   &:hover {
-    background-color: var(--action-color-alt);
+    background-color: $action-color-alt;
   }
 
   &:focus {

--- a/core/_buttons.scss
+++ b/core/_buttons.scss
@@ -2,25 +2,25 @@
   appearance: none;
   background-color: $action-color;
   border: 0;
-  border-radius: var(--base-border-radius);
+  border-radius: var(--border-radius);
   color: inherit;
   cursor: pointer;
   display: inline-block;
-  font-family: var(--base-font-family);
+  font-family: var(--font-family-base);
   font-size: 16px;
   -webkit-font-smoothing: antialiased;
   font-weight: 600;
   line-height: 1;
-  padding: var(--small-spacing) var(--base-spacing);
+  padding: var(--spacing--small) var(--spacing);
   text-align: center;
   text-decoration: none;
-  transition: background-color var(--base-duration) var(--base-timing);
+  transition: background-color var(--duration) var(--timing);
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
 
   &:hover {
-    background-color: $action-color-alt;
+    background-color: $action-color--alt;
   }
 
   &:focus {

--- a/core/_buttons.scss
+++ b/core/_buttons.scss
@@ -1,43 +1,31 @@
-$_button-background-color: $action-color;
-$_button-background-color-hover: shade($action-color, 20%);
-
 #{$all-buttons} {
   appearance: none;
-  background-color: $_button-background-color;
+  background-color: var(--action-color);
   border: 0;
-  border-radius: $base-border-radius;
-  color: contrast-switch($_button-background-color);
+  border-radius: var(--base-border-radius);
+  color: inherit;
   cursor: pointer;
   display: inline-block;
-  font-family: $base-font-family;
+  font-family: var(--base-font-family);
   font-size: 16px;
   -webkit-font-smoothing: antialiased;
   font-weight: 600;
   line-height: 1;
-  padding: $small-spacing $base-spacing;
+  padding: var(--small-spacing) var(--base-spacing);
   text-align: center;
   text-decoration: none;
-  transition: background-color $base-duration $base-timing;
+  transition: background-color var(--base-duration) var(--base-timing);
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
 
-  &:hover {
-    background-color: $_button-background-color-hover;
-    color: contrast-switch($_button-background-color-hover);
-  }
-
   &:focus {
-    outline: $focus-outline;
-    outline-offset: $focus-outline-offset;
+    outline: var(--focus-outline);
+    outline-offset: var(--focus-outline-offset);
   }
 
   &:disabled {
     cursor: not-allowed;
     opacity: 0.5;
-
-    &:hover {
-      background-color: $_button-background-color;
-    }
   }
 }

--- a/core/_forms.scss
+++ b/core/_forms.scss
@@ -1,6 +1,8 @@
-$_form-background-color: #fff;
-$_form-box-shadow: inset 0 1px 3px rgba(#000, 0.06);
-$_form-box-shadow-focus: $_form-box-shadow, 0 0 5px rgba($action-color, 0.7);
+:root {
+  --form-background-color: var(--viewport-background-color);
+  --form-box-shadow: inset 0 1px 3px rgba(#000, 0.06);
+  --form-box-shadow-focus: var(--form-box-shadow), 0 0 5px var(--action-color);
+}
 
 fieldset {
   background-color: transparent;
@@ -11,57 +13,54 @@ fieldset {
 
 legend {
   font-weight: 600;
-  margin-bottom: $small-spacing / 2;
+  margin-bottom: var(--small-spacing);
   padding: 0;
 }
 
 label {
   display: block;
   font-weight: 600;
-  margin-bottom: $small-spacing / 2;
+  margin-bottom: var(--small-spacing);
 }
 
 input,
 select,
 textarea {
   display: block;
-  font-family: $base-font-family;
+  font-family: var(--base-font-family);
   font-size: 16px;
 }
 
 #{$all-text-inputs} {
   appearance: none;
-  background-color: $_form-background-color;
-  border: $base-border;
-  border-radius: $base-border-radius;
-  box-shadow: $_form-box-shadow;
+  background-color: var(--form-background-color);
+  border: var(--base-border);
+  border-radius: var(--base-border-radius);
+  box-shadow: var(--form-box-shadow);
   box-sizing: border-box;
-  margin-bottom: $small-spacing;
-  padding: $base-spacing / 3;
-  transition: border-color $base-duration $base-timing;
+  margin-bottom: var(--small-spacing);
+  padding: calc(var(--base-spacing) / 3);
+  transition: border-color var(--base-duration) var(--base-timing);
   width: 100%;
 
-  &:hover {
-    border-color: shade($base-border-color, 20%);
-  }
-
   &:focus {
-    border-color: $action-color;
-    box-shadow: $_form-box-shadow-focus;
+    border-color: var(--action-color);
+    box-shadow: var(--form-box-shadow-focus);
     outline: none;
   }
 
   &:disabled {
-    background-color: shade($_form-background-color, 5%);
+    background-color: var(--form-background-color);
     cursor: not-allowed;
 
     &:hover {
-      border: $base-border;
+      border: var(--base-border);
     }
   }
 
   &::placeholder {
-    color: tint($base-font-color, 40%);
+    color: var(--base-font-color);
+    opacity: 0.25;
   }
 }
 
@@ -72,16 +71,16 @@ textarea {
 [type="checkbox"],
 [type="radio"] {
   display: inline;
-  margin-right: $small-spacing / 2;
+  margin-right: var(--small-spacing);
 }
 
 [type="file"] {
-  margin-bottom: $small-spacing;
+  margin-bottom: var(--small-spacing);
   width: 100%;
 }
 
 select {
-  margin-bottom: $small-spacing;
+  margin-bottom: var(--small-spacing);
   width: 100%;
 }
 
@@ -90,7 +89,7 @@ select {
 [type="file"],
 select {
   &:focus {
-    outline: $focus-outline;
-    outline-offset: $focus-outline-offset;
+    outline: var(--focus-outline);
+    outline-offset: var(--focus-outline-offset);
   }
 }

--- a/core/_forms.scss
+++ b/core/_forms.scss
@@ -1,5 +1,3 @@
-$__form-background-color: $viewport-background-color;
-
 :root {
   --form-box-shadow: inset 0 1px 3px rgba(#000, 0.06);
   --form-box-shadow-focus: var(--form-box-shadow), 0 0 5px #{$action-color};
@@ -14,53 +12,51 @@ fieldset {
 
 legend {
   font-weight: 600;
-  margin-bottom: var(--small-spacing);
+  margin-bottom: var(--spacing--small);
   padding: 0;
 }
 
 label {
   display: block;
   font-weight: 600;
-  margin-bottom: var(--small-spacing);
+  margin-bottom: var(--spacing--small);
 }
 
 input,
 select,
 textarea {
   display: block;
-  font-family: var(--base-font-family);
+  font-family: var(--font-family);
   font-size: 16px;
 }
 
 #{$all-text-inputs} {
   appearance: none;
-  background-color: $__form-background-color;
-  border: var(--base-border);
-  border-radius: var(--base-border-radius);
+  background-color: transparent;
+  border: var(--border);
+  border-radius: var(--border-radius);
   box-shadow: var(--form-box-shadow);
   box-sizing: border-box;
-  margin-bottom: var(--small-spacing);
-  padding: calc(var(--base-spacing) / 3);
-  transition: border-color var(--base-duration) var(--base-timing);
+  margin-bottom: var(--spacing--small);
+  padding: calc(var(--spacing) / 3);
+  transition: border-color var(--duration) var(--timing);
   width: 100%;
 
   &:focus {
-    border-color: var(--base-border-color-alt);
     box-shadow: var(--form-box-shadow-focus);
     outline: none;
   }
 
   &:disabled {
-    background-color: $__form-background-color;
     cursor: not-allowed;
 
     &:hover {
-      border: var(--base-border);
+      border: var(--border);
     }
   }
 
   &::placeholder {
-    color: $base-font-color;
+    color: $font-color--base;
     opacity: 0.25;
   }
 }
@@ -72,16 +68,16 @@ textarea {
 [type="checkbox"],
 [type="radio"] {
   display: inline;
-  margin-right: var(--small-spacing);
+  margin-right: var(--spacing--small);
 }
 
 [type="file"] {
-  margin-bottom: var(--small-spacing);
+  margin-bottom: var(--spacing--small);
   width: 100%;
 }
 
 select {
-  margin-bottom: var(--small-spacing);
+  margin-bottom: var(--spacing--small);
   width: 100%;
 }
 

--- a/core/_forms.scss
+++ b/core/_forms.scss
@@ -44,7 +44,7 @@ textarea {
   width: 100%;
 
   &:focus {
-    border-color: var(--action-color);
+    border-color: var(--base-border-color-alt);
     box-shadow: var(--form-box-shadow-focus);
     outline: none;
   }

--- a/core/_forms.scss
+++ b/core/_forms.scss
@@ -1,7 +1,8 @@
+$__form-background-color: $viewport-background-color;
+
 :root {
-  --form-background-color: var(--viewport-background-color);
   --form-box-shadow: inset 0 1px 3px rgba(#000, 0.06);
-  --form-box-shadow-focus: var(--form-box-shadow), 0 0 5px var(--action-color);
+  --form-box-shadow-focus: var(--form-box-shadow), 0 0 5px #{$action-color};
 }
 
 fieldset {
@@ -33,7 +34,7 @@ textarea {
 
 #{$all-text-inputs} {
   appearance: none;
-  background-color: var(--form-background-color);
+  background-color: $__form-background-color;
   border: var(--base-border);
   border-radius: var(--base-border-radius);
   box-shadow: var(--form-box-shadow);
@@ -50,7 +51,7 @@ textarea {
   }
 
   &:disabled {
-    background-color: var(--form-background-color);
+    background-color: $__form-background-color;
     cursor: not-allowed;
 
     &:hover {
@@ -59,7 +60,7 @@ textarea {
   }
 
   &::placeholder {
-    color: var(--base-font-color);
+    color: $base-font-color;
     opacity: 0.25;
   }
 }

--- a/core/_layout.scss
+++ b/core/_layout.scss
@@ -1,5 +1,5 @@
 html {
-  background-color: var(--viewport-background-color);
+  background-color: $viewport-background-color;
   box-sizing: border-box;
 }
 

--- a/core/_layout.scss
+++ b/core/_layout.scss
@@ -1,5 +1,5 @@
 html {
-  background-color: $viewport-background-color;
+  background-color: var(--viewport-background-color);
   box-sizing: border-box;
 }
 

--- a/core/_tables.scss
+++ b/core/_tables.scss
@@ -1,13 +1,13 @@
 table {
   border-collapse: collapse;
-  margin: var(--base-spacing) 0;
+  margin: var(--spacing) 0;
   table-layout: fixed;
   text-align: left;
   width: 100%;
 }
 
 thead {
-  line-height: var(--heading-line-height);
+  line-height: var(--line-height--heading);
   vertical-align: bottom;
 }
 
@@ -16,7 +16,7 @@ tbody {
 }
 
 tr {
-  border-bottom: var(--base-border);
+  border-bottom: var(--border);
 }
 
 th {
@@ -25,5 +25,5 @@ th {
 
 th,
 td {
-  padding: var(--small-spacing) var(--small-spacing) var(--small-spacing) 0;
+  padding: var(--spacing--small) var(--spacing--small) var(--spacing--small) 0;
 }

--- a/core/_tables.scss
+++ b/core/_tables.scss
@@ -1,13 +1,13 @@
 table {
   border-collapse: collapse;
-  margin: $base-spacing 0;
+  margin: var(--base-spacing) 0;
   table-layout: fixed;
   text-align: left;
   width: 100%;
 }
 
 thead {
-  line-height: $heading-line-height;
+  line-height: var(--heading-line-height);
   vertical-align: bottom;
 }
 
@@ -16,7 +16,7 @@ tbody {
 }
 
 tr {
-  border-bottom: $base-border;
+  border-bottom: var(--base-border);
 }
 
 th {
@@ -25,5 +25,5 @@ th {
 
 th,
 td {
-  padding: $small-spacing $small-spacing $small-spacing 0;
+  padding: var(--small-spacing) var(--small-spacing) var(--small-spacing) 0;
 }

--- a/core/_typography.scss
+++ b/core/_typography.scss
@@ -27,7 +27,7 @@ a {
   transition: color var(--base-duration) var(--base-timing);
 
   &:hover {
-    color: var(--action-color);
+    color: var(--action-color-alt);
   }
 
   &:focus {

--- a/core/_typography.scss
+++ b/core/_typography.scss
@@ -1,8 +1,8 @@
 html {
-  color: $base-font-color;
-  font-family: $base-font-family;
+  color: var(--base-font-color);
+  font-family: var(--base-font-family);
   font-size: 100%;
-  line-height: $base-line-height;
+  line-height: var(--base-line-height);
 }
 
 h1,
@@ -11,35 +11,35 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: $heading-font-family;
+  font-family: var(--heading-font-family);
   font-size: modular-scale(1);
-  line-height: $heading-line-height;
-  margin: 0 0 $small-spacing;
+  line-height: var(--heading-line-height);
+  margin: 0 0 var(--small-spacing);
 }
 
 p {
-  margin: 0 0 $small-spacing;
+  margin: 0 0 var(--small-spacing);
 }
 
 a {
-  color: $action-color;
+  color: var(--action-color);
   text-decoration-skip: ink;
-  transition: color $base-duration $base-timing;
+  transition: color var(--base-duration) var(--base-timing);
 
   &:hover {
-    color: shade($action-color, 25%);
+    color: var(--action-color);
   }
 
   &:focus {
-    outline: $focus-outline;
-    outline-offset: $focus-outline-offset;
+    outline: var(--focus-outline);
+    outline-offset: var(--focus-outline-offset);
   }
 }
 
 hr {
-  border-bottom: $base-border;
+  border-bottom: var(--base-border);
   border-left: 0;
   border-right: 0;
   border-top: 0;
-  margin: $base-spacing 0;
+  margin: var(--base-spacing) 0;
 }

--- a/core/_typography.scss
+++ b/core/_typography.scss
@@ -1,8 +1,8 @@
 html {
-  color: $base-font-color;
-  font-family: var(--base-font-family);
+  color: $font-color--base;
+  font-family: var(--font-family);
   font-size: 100%;
-  line-height: var(--base-line-height);
+  line-height: var(--line-height);
 }
 
 h1,
@@ -11,23 +11,23 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: var(--heading-font-family);
+  font-family: var(--font-family--heading);
   font-size: modular-scale(1);
-  line-height: var(--heading-line-height);
-  margin: 0 0 var(--small-spacing);
+  line-height: var(--line-height--heading);
+  margin: 0 0 var(--spacing--small);
 }
 
 p {
-  margin: 0 0 var(--small-spacing);
+  margin: 0 0 var(--spacing--small);
 }
 
 a {
   color: $action-color;
   text-decoration-skip: ink;
-  transition: color var(--base-duration) var(--base-timing);
+  transition: color var(--duration) var(--timing);
 
   &:hover {
-    color: $action-color-alt;
+    color: $action-color--alt;
   }
 
   &:focus {
@@ -37,9 +37,9 @@ a {
 }
 
 hr {
-  border-bottom: var(--base-border);
+  border-bottom: var(--border);
   border-left: 0;
   border-right: 0;
   border-top: 0;
-  margin: var(--base-spacing) 0;
+  margin: var(--spacing) 0;
 }

--- a/core/_typography.scss
+++ b/core/_typography.scss
@@ -1,5 +1,5 @@
 html {
-  color: var(--base-font-color);
+  color: $base-font-color;
   font-family: var(--base-font-family);
   font-size: 100%;
   line-height: var(--base-line-height);
@@ -22,12 +22,12 @@ p {
 }
 
 a {
-  color: var(--action-color);
+  color: $action-color;
   text-decoration-skip: ink;
   transition: color var(--base-duration) var(--base-timing);
 
   &:hover {
-    color: var(--action-color-alt);
+    color: $action-color-alt;
   }
 
   &:focus {

--- a/core/_variables.scss
+++ b/core/_variables.scss
@@ -3,6 +3,16 @@
   --base-font-family: #{$font-stack-system};
   --heading-font-family: var(--base-font-family);
 
+  --font-weight-thin: 100;
+  --font-weight-extra-light: 200;
+  --font-weight-light: 300;
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
+  --font-weight-semi-bold: 600;
+  --font-weight-bold: 700;
+  --font-weight-extra-bold: 800;
+  --font-weight-black: 900;
+
   // Line height
   --base-line-height: 1.5;
   --heading-line-height: 1.2;

--- a/core/_variables.scss
+++ b/core/_variables.scss
@@ -1,3 +1,9 @@
+// Colors
+$blue: #1565c0;
+$blue-light: #3b83d5;
+$gray-dark: #333;
+$gray-light: #ddd;
+
 :root {
   // Typography
   --base-font-family: #{$font-stack-system};
@@ -22,17 +28,14 @@
   --base-spacing: 1.5rem;
   --small-spacing: 0.75rem;
 
-  // Colors
-  --blue: #1565c0;
-  --dark-gray: #333;
-  --light-gray: #ddd;
-
   // Font Colors
-  --base-font-color: var(--dark-gray);
-  --action-color: var(--blue);
+  --base-font-color: $gray-dark;
+  --action-color: $blue;
+  --action-color-alt: $blue-light;
 
   // Border
-  --base-border-color: var(--light-gray);
+  --base-border-color: $gray-light;
+  --base-border-color-alt: $gray-dark;
   --base-border: 1px solid var(--base-border-color);
 
   // Background Colors

--- a/core/_variables.scss
+++ b/core/_variables.scss
@@ -1,40 +1,40 @@
-// Typography
-$base-font-family: $font-stack-system;
-$heading-font-family: $base-font-family;
+:root {
+  // Typography
+  --base-font-family: #{$font-stack-system};
+  --heading-font-family: var(--base-font-family);
 
-// Line height
-$base-line-height: 1.5;
-$heading-line-height: 1.2;
+  // Line height
+  --base-line-height: 1.5;
+  --heading-line-height: 1.2;
 
-// Other Sizes
-$base-border-radius: 3px;
-$base-spacing: 1.5em;
-$small-spacing: $base-spacing / 2;
-$base-z-index: 0;
+  // Other Sizes
+  --base-border-radius: 3px;
+  --base-spacing: 1.5rem;
+  --small-spacing: 0.75rem;
 
-// Colors
-$blue: #1565c0;
-$dark-gray: #333;
-$medium-gray: #999;
-$light-gray: #ddd;
+  // Colors
+  --blue: #1565c0;
+  --dark-gray: #333;
+  --light-gray: #ddd;
 
-// Font Colors
-$base-font-color: $dark-gray;
-$action-color: $blue;
+  // Font Colors
+  --base-font-color: var(--dark-gray);
+  --action-color: var(--blue);
 
-// Border
-$base-border-color: $light-gray;
-$base-border: 1px solid $base-border-color;
+  // Border
+  --base-border-color: var(--light-gray);
+  --base-border: 1px solid var(--base-border-color);
 
-// Background Colors
-$viewport-background-color: #fff;
+  // Background Colors
+  --viewport-background-color: #fff;
 
-// Focus
-$focus-outline-color: transparentize($action-color, 0.4);
-$focus-outline-width: 3px;
-$focus-outline: $focus-outline-width solid $focus-outline-color;
-$focus-outline-offset: 2px;
+  // Focus
+  --focus-outline-color: var(--action-color);
+  --focus-outline-width: 3px;
+  --focus-outline: var(--focus-outline-width) solid var(--focus-outline-color);
+  --focus-outline-offset: 2px;
 
-// Animations
-$base-duration: 150ms;
-$base-timing: ease;
+  // Animations
+  --base-duration: 150ms;
+  --base-timing: ease;
+}

--- a/core/_variables.scss
+++ b/core/_variables.scss
@@ -4,6 +4,18 @@ $blue-light: #3b83d5;
 $gray-dark: #333;
 $gray-light: #ddd;
 
+// Font Colors
+$base-font-color: $gray-dark;
+$action-color: $blue;
+$action-color-alt: $blue-light;
+
+// Border Colors
+$base-border-color: $gray-light;
+$base-border-color-alt: $gray-dark;
+
+// Background Colors
+$viewport-background-color: #fff;
+
 :root {
   // Typography
   --base-font-family: #{$font-stack-system};
@@ -19,7 +31,7 @@ $gray-light: #ddd;
   --font-weight-extra-bold: 800;
   --font-weight-black: 900;
 
-  // Line height
+  // Line heights
   --base-line-height: 1.5;
   --heading-line-height: 1.2;
 
@@ -28,23 +40,12 @@ $gray-light: #ddd;
   --base-spacing: 1.5rem;
   --small-spacing: 0.75rem;
 
-  // Font Colors
-  --base-font-color: $gray-dark;
-  --action-color: $blue;
-  --action-color-alt: $blue-light;
-
-  // Border
-  --base-border-color: $gray-light;
-  --base-border-color-alt: $gray-dark;
-  --base-border: 1px solid var(--base-border-color);
-
-  // Background Colors
-  --viewport-background-color: #fff;
+  // Borders
+  --base-border: 1px solid #{$base-border-color};
 
   // Focus
-  --focus-outline-color: var(--action-color);
   --focus-outline-width: 3px;
-  --focus-outline: var(--focus-outline-width) solid var(--focus-outline-color);
+  --focus-outline: var(--focus-outline-width) solid #{$action-color};
   --focus-outline-offset: 2px;
 
   // Animations

--- a/core/_variables.scss
+++ b/core/_variables.scss
@@ -5,50 +5,46 @@ $gray-dark: #333;
 $gray-light: #ddd;
 
 // Font Colors
-$base-font-color: $gray-dark;
+$font-color--base: $gray-dark;
 $action-color: $blue;
-$action-color-alt: $blue-light;
-
-// Border Colors
-$base-border-color: $gray-light;
-$base-border-color-alt: $gray-dark;
+$action-color--alt: $blue-light;
 
 // Background Colors
 $viewport-background-color: #fff;
 
 :root {
   // Typography
-  --base-font-family: #{$font-stack-system};
-  --heading-font-family: var(--base-font-family);
+  --font-family: #{$font-stack-system};
+  --font-family--heading: var(--font-family);
 
-  --font-weight-thin: 100;
-  --font-weight-extra-light: 200;
-  --font-weight-light: 300;
-  --font-weight-normal: 400;
-  --font-weight-medium: 500;
-  --font-weight-semi-bold: 600;
-  --font-weight-bold: 700;
-  --font-weight-extra-bold: 800;
-  --font-weight-black: 900;
+  --font-weight--thin: 100;
+  --font-weight--extra-light: 200;
+  --font-weight--light: 300;
+  --font-weight--normal: 400;
+  --font-weight--medium: 500;
+  --font-weight--semi-bold: 600;
+  --font-weight--bold: 700;
+  --font-weight--extra-bold: 800;
+  --font-weight--black: 900;
 
   // Line heights
-  --base-line-height: 1.5;
-  --heading-line-height: 1.2;
+  --line-height: 1.5;
+  --line-height--heading: 1.2;
 
   // Other Sizes
-  --base-border-radius: 3px;
-  --base-spacing: 1.5rem;
-  --small-spacing: 0.75rem;
+  --border-radius: 3px;
+  --spacing: 1.5rem;
+  --spacing--small: 0.75rem;
 
   // Borders
-  --base-border: 1px solid #{$base-border-color};
+  --border: 1px solid currentColor;
 
   // Focus
   --focus-outline-width: 3px;
-  --focus-outline: var(--focus-outline-width) solid #{$action-color};
   --focus-outline-offset: 2px;
+  --focus-outline: var(--focus-outline-width) solid #{$action-color};
 
   // Animations
-  --base-duration: 150ms;
-  --base-timing: ease;
+  --duration: 150ms;
+  --timing: ease;
 }


### PR DESCRIPTION
- Removed unused `base-z-index` variable
- Removed unused `medium-gray` variable

Little to no visual changes. Some hover effects have been removed due to the inability to run color manipulations on css variables so a few of them just stay the same on over.