### PR TITLE
Remove bourbon runtime dependency

### DIFF
--- a/bitters.gemspec
+++ b/bitters.gemspec
@@ -6,7 +6,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "bundler", "~> 1.3"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
-  s.add_runtime_dependency "bourbon", "~> 5.0"
   s.add_runtime_dependency "sass", "~> 3.4"
   s.add_runtime_dependency "thor", "~> 0.19"
   s.authors = [

--- a/spec/bitters_spec.rb
+++ b/spec/bitters_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 require 'sass'
-require 'bourbon'
 
 describe Bitters do
   after do

--- a/spec/fixtures/application.scss
+++ b/spec/fixtures/application.scss
@@ -1,2 +1,1 @@
-@import "bourbon";
 @import "base/base";


### PR DESCRIPTION
[`e2303a1`][e2303a1] removed bourbon as a dependency, but it was still a runtime
dependency in the gemspec.

Closes https://github.com/thoughtbot/bitters/issues/328

[e2303a1]: https://github.com/thoughtbot/bitters/commit/e2303a11219d5eeb2db8351eb1baa1061efc17c7