### PR TITLE
Make sass a development dependency

### DIFF
--- a/bitters.gemspec
+++ b/bitters.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "bundler", "~> 1.3"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
-  s.add_runtime_dependency "sass", "~> 3.4"
+  s.add_development_dependency "sass", "~> 3.4"
   s.add_runtime_dependency "thor", "~> 0.19"
   s.authors = [
     "Kyle Fiedler",


### PR DESCRIPTION
As we've done in Bourbon ([`9bedac0`][9bedac0]) and
Neat ([`a46f8dc`][a46f8dc]), remove the Ruby implementation of Sass as
a runtime dependency.

Why? Three reasons:

1. Bitters is not designed to be used as a library, so there's really no 
  runtime dependencies.
1. The Ruby-based Sass implementation is now deprecated.
1. We do have a test suite here, so we need Sass as a development
  dependency to run that.

[9bedac0]: https://github.com/thoughtbot/bourbon/commit/9bedac008832cb779ded2f9298f12a5ebae9e88a
[a46f8dc]: https://github.com/thoughtbot/neat/commit/a46f8dc87efdea09734682aa5cb8c7d4fcbef738