### PR TITLE
Remove links to website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[<img src="https://images.thoughtbot.com/bourbon/bitters-logo-v2.svg" width="200" alt="Bitters">](http://bitters.bourbon.io)
+<img src="https://images.thoughtbot.com/bourbon/bitters-logo-v2.svg" width="200" alt="Bitters">
 
 [![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)
 
@@ -17,7 +17,6 @@ one. We like to use [Normalize].
 
 ### Helpful Links
 
-- [Demo](http://bitters.bourbon.io)
 - [Change log](CHANGELOG.md)
 - [Twitter](https://twitter.com/bourbonsass)
 - [Stack Overflow](https://stackoverflow.com/questions/tagged/bitters)

--- a/bitters.gemspec
+++ b/bitters.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.email = "design+bitters@thoughtbot.com"
   s.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.files = `git ls-files`.split($/)
-  s.homepage = "http://bitters.bourbon.io"
+  s.homepage = "https://github.com/thoughtbot/bitters"
   s.license = "MIT"
   s.name = "bitters"
   s.require_paths = ["lib"]

--- a/contrib/index.html
+++ b/contrib/index.html
@@ -11,8 +11,7 @@
     <header class="welcome-message" role="banner">
       <div class="container">
         <h1>
-          Hey there! Thanks for contributing to
-          <a href="http://bitters.bourbon.io">Bitters</a>.
+          Hey there! Thanks for contributing to Bitters.
         </h1>
         <p>
           The purpose of this page is to help contributors view and test

--- a/core/_base.scss
+++ b/core/_base.scss
@@ -1,5 +1,5 @@
 // Bitters 2.0.1
-// http://bitters.bourbon.io
+// https://github.com/thoughtbot/bitters
 // Copyright 2013-2019 thoughtbot, inc.
 // MIT License
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "bugs": {
     "url": "https://github.com/thoughtbot/bitters/issues"
   },
-  "homepage": "http://bitters.bourbon.io",
   "devDependencies": {
     "@thoughtbot/stylelint-config": "^1.0.2",
     "bourbon": "^6.0.0",


### PR DESCRIPTION
We're no longer maintaining the website and it's URL will now redirect
to https://github.com/thoughtbot/bitters.

Related: https://github.com/thoughtbot/bitters/issues/326