### PR TITLE
Remove duplication of normalize.css body styles

### DIFF
--- a/core/_layout.scss
+++ b/core/_layout.scss
@@ -13,7 +13,3 @@ html,
 body {
   height: 100%;
 }
-
-body {
-  margin: 0;
-}


### PR DESCRIPTION
We added these styles in [6059fb2] because normalize.css 6.0.0 removed
them. However, they were added back to normalize.csss in [b4a8fda].
There is no reason for these styles to exist in Bitters because we
encourage Bitters to be used alongside Normalize.

[6059fb2]: https://github.com/thoughtbot/bitters/commit/6059fb256d8a9186528d97f214a9067eea3c54e7
[b4a8fda]: https://github.com/necolas/normalize.css/commit/b4a8fdaf8321093b1e3cad612fb76cf2b7d3275d