### PR TITLE
Switch to Dart Sass for contributing site

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -3,6 +3,8 @@ const browserSync = require('browser-sync').create();
 const gulp = require('gulp');
 const sass = require('gulp-sass');
 
+sass.compiler = require('sass');
+
 const paths = {
   markup: {
     src: './contrib/**/*.html',

--- a/package-lock.json
+++ b/package-lock.json
@@ -6864,6 +6864,15 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "sass": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.23.0.tgz",
+      "integrity": "sha512-W4HT8+WE31Rzk3EPQC++CXjD5O+lOxgYBIB8Ohvt7/zeE2UzYW+TOczDrRU3KcEy3+xwXXbmDsOZFkoqgD4TKw==",
+      "dev": true,
+      "requires": {
+        "chokidar": ">=2.0.0 <4.0.0"
+      }
+    },
     "sass-graph": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "eslint": "5.16.0",
     "gulp": "^4.0.2",
     "gulp-sass": "^4.0.2",
+    "sass": "^1.23.0",
     "stylelint": "^10.1.0"
   },
   "scripts": {


### PR DESCRIPTION
Dart Sass is the primary implementation of Sass and is distributed as
the pure JavaScript `sass` package on npm. This configures gulp-sass to
use Dart Sass, instead of Node Sass.

https://github.com/dlmanning/gulp-sass#basic-usage