### PR TITLE
Remove Bourbon Family section from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,14 +134,6 @@ bitters [options]
 | `bitters help`    | Show help                                             |
 | `bitters version` | Show the version number                               |
 
-## The Bourbon Family
-
-- [Bourbon]: A Lightweight Sass Tool Set
-- [Neat]: A lightweight and flexible Sass grid
-
-[Bourbon]: https://github.com/thoughtbot/bourbon
-[Neat]: https://github.com/thoughtbot/neat
-
 ## Contributing
 
 See the [contributing] document. Thank you, [contributors]!


### PR DESCRIPTION
We don't encourage use of Neat anymore, and Bourbon was removed as a
dependency to Bitters recently. It doesn't make sense to call this the
"Bourbon Family" anymore.