### PR TITLE
Update to text-decoration-skip-ink property

### DIFF
--- a/core/_typography.scss
+++ b/core/_typography.scss
@@ -23,7 +23,7 @@ p {
 
 a {
   color: $action-color;
-  text-decoration-skip: ink;
+  text-decoration-skip-ink: auto;
   transition: color var(--duration) var(--timing);
 
   &:hover {


### PR DESCRIPTION
The `ink` value for  has been deprecated and [according to MDN][mdn]
"…browsers are converging on supporting the simpler
`text-decoration-skip-ink` property."

- [Can I use support for `text-decoration-skip` with `ink` value][caniuse-skip]
- [Can I use support for `text-decoration-skip-ink`][caniuse-skip-ink]

[mdn]: https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-skip
[caniuse-skip]: https://caniuse.com/#feat=mdn-css_properties_text-decoration-skip
[caniuse-skip-ink]: https://caniuse.com/#feat=mdn-css_properties_text-decoration-skip-ink