### PR TITLE
Remove Bourbon modular-scale function

### DIFF
--- a/core/_typography.scss
+++ b/core/_typography.scss
@@ -12,7 +12,7 @@ h4,
 h5,
 h6 {
   font-family: var(--font-family--heading);
-  font-size: modular-scale(1);
+  font-size: 1.25rem;
   line-height: var(--line-height--heading);
   margin: 0 0 var(--spacing--small);
 }


### PR DESCRIPTION
This commit removes the Bourbon modular-scale function.

Bourbon was removed in https://github.com/thoughtbot/bitters/commit/e2303a11219d5eeb2db8351eb1baa1061efc17c7.

Closes https://github.com/thoughtbot/bitters/issues/337