### PR TITLE
Add `height: auto` to `img`

### DIFF
--- a/core/_media.scss
+++ b/core/_media.scss
@@ -2,8 +2,11 @@ figure {
   margin: 0;
 }
 
-img,
 picture {
   margin: 0;
+}
+
+img {
+  height: auto;
   max-width: 100%;
 }


### PR DESCRIPTION
Applying `max-width: 100%` to an `img` that has its HTML `width` and
`height` attributes set means its aspect ratio won't be maintained and
the image can appear squished.

Closes: https://github.com/thoughtbot/bitters/issues/354