### PR TITLE
Ensure the HTML `hidden` attribute hides content

### DIFF
--- a/core/_layout.scss
+++ b/core/_layout.scss
@@ -13,3 +13,8 @@ html,
 body {
   height: 100%;
 }
+
+[hidden] {
+  // stylelint-disable-next-line declaration-no-important
+  display: none !important;
+}


### PR DESCRIPTION
The HTML `hidden` attribute is, in terms of specificity, very weak.
This commit adds `display: none !important;` to the `[hidden]`
attribute to ensure that elements using it are actually hidden.

More info: https://css-tricks.com/the-hidden-attribute-is-visibly-weak/

Closes: https://github.com/thoughtbot/bitters/issues/342