### PR TITLE
Deploy contributing site to Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,9 @@
+[build]
+  publish = "contrib/build"
+  command = "npx parcel build contrib/index.html --out-dir contrib/build"
+
+[[redirects]]
+  from = "https://bitters.netlify.com/*"
+  to = "https://github.com/thoughtbot/bitters"
+  status = 301
+  force = true


### PR DESCRIPTION
This add configuration to deploy the contributing site to Netlify so 
that we can get deploy previews for each GitHub Pull Request. This makes 
it easier to review code and visual changes.

Since we don't intend for this contributing site to be public-facing,
a redirect is added to point the Netlify site to the Bitters GitHub
repo.

Netlify documentation on `netlify.toml`:
https://docs.netlify.com/configure-builds/file-based-configuration/

Closes: https://github.com/thoughtbot/bitters/issues/355