### PR TITLE
Font weights

### DIFF
--- a/core/_buttons.scss
+++ b/core/_buttons.scss
@@ -12,7 +12,7 @@ button,
   font-family: var(--font-family-base);
   font-size: 1rem;
   -webkit-font-smoothing: antialiased;
-  font-weight: 600;
+  font-weight: var(--font-weight--semi-bold);
   line-height: 1;
   padding: var(--spacing--small) var(--spacing);
   text-align: center;

--- a/core/_forms.scss
+++ b/core/_forms.scss
@@ -11,14 +11,14 @@ fieldset {
 }
 
 legend {
-  font-weight: 600;
+  font-weight: var(--font-weight--semi-bold);
   margin-bottom: var(--spacing--small);
   padding: 0;
 }
 
 label {
   display: block;
-  font-weight: 600;
+  font-weight: var(--font-weight--semi-bold);
   margin-bottom: var(--spacing--small);
 }
 

--- a/core/_lists.scss
+++ b/core/_lists.scss
@@ -10,7 +10,7 @@ dl {
 }
 
 dt {
-  font-weight: 600;
+  font-weight: var(--font-weight--semi-bold);
   margin: 0;
 }
 

--- a/core/_tables.scss
+++ b/core/_tables.scss
@@ -20,7 +20,7 @@ tr {
 }
 
 th {
-  font-weight: 600;
+  font-weight: var(--font-weight--semi-bold);
 }
 
 th,

--- a/core/_variables.scss
+++ b/core/_variables.scss
@@ -18,15 +18,10 @@ $viewport-background-color: $white;
   --font-family: system-ui, sans-serif;
   --font-family--heading: var(--font-family);
 
-  --font-weight--thin: 100;
-  --font-weight--extra-light: 200;
-  --font-weight--light: 300;
   --font-weight--normal: 400;
   --font-weight--medium: 500;
   --font-weight--semi-bold: 600;
   --font-weight--bold: 700;
-  --font-weight--extra-bold: 800;
-  --font-weight--black: 900;
 
   // Line heights
   --line-height: 1.5;


### PR DESCRIPTION
-  Use provided font weight custom properties (closes #340)
- Remove superfluous font weight custom properties
    - Bitters is generally designed for user interfaces and I find that, in
      that context, I extremely rarely use font weights like black (`900`),
      thin (`100`) and others. In fact, I'm not sure I've ever used a thin
      font weight.
    - Given, I don't think Bitters needs to provide this many font weights.
      Let's stick to the core weights that are commonly used. It's easy
      enough to add to these in your project, if needed.

