### PR TITLE
Add normalize.css to contributing site

### DIFF
--- a/contrib/styles.scss
+++ b/contrib/styles.scss
@@ -1,9 +1,6 @@
 @import "~node_modules/bourbon/core/bourbon";
+@import "~node_modules/normalize.css/normalize";
 @import "../core/base";
-
-body {
-  margin: 0 0 calc(var(--spacing) * 2);
-}
 
 .container {
   margin: 0 auto;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8293,6 +8293,12 @@
       "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
       "dev": true
     },
+    "normalize.css": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
+      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==",
+      "dev": true
+    },
     "nth-check": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@thoughtbot/stylelint-config": "^1.1.0",
     "bourbon": "^6.0.0",
     "eslint": "5.16.0",
+    "normalize.css": "^8.0.1",
     "parcel-bundler": "^1.12.4",
     "sass": "^1.23.0",
     "stylelint": "^10.1.0"


### PR DESCRIPTION
We encourage Bitters to be used alongside normalize.css. This commit
adds normalize.css to the contributing site to make sure it is a
realistic utility.

Closes: https://github.com/thoughtbot/bitters/issues/348