### PR TITLE
Linters

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,8 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "weekly"
+    ignored_updates:
+      - match:
+          dependency_name: "*stylelint*"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,0 @@
-{
-  "extends": "@thoughtbot/eslint-config",
-  "env": {
-    "es6": true
-  }
-}

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,7 +1,5 @@
 eslint:
-  enabled: true
-  config_file: .eslintrc.json
-  version: 5.16.0
+  enabled: false
 ruby:
   enabled: true
 scss:

--- a/package.json
+++ b/package.json
@@ -21,17 +21,14 @@
     "url": "https://github.com/thoughtbot/bitters/issues"
   },
   "devDependencies": {
-    "@thoughtbot/eslint-config": "^0.1.0",
     "@thoughtbot/stylelint-config": "^1.1.0",
     "bourbon": "^6.0.0",
-    "eslint": "5.16.0",
     "parcel-bundler": "^1.12.4",
     "sass": "^1.23.0",
     "stylelint": "^10.1.0"
   },
   "scripts": {
     "contrib": "npx parcel contrib/index.html --out-dir contrib/build",
-    "eslint": "npx eslint '**/*.js'",
     "stylelint": "npx stylelint 'core/**/*.scss'"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "url": "https://github.com/thoughtbot/bitters/issues"
   },
   "devDependencies": {
-    "@thoughtbot/stylelint-config": "^1.1.0",
+    "@thoughtbot/stylelint-config": "1.1.0",
     "bourbon": "^6.0.0",
     "parcel-bundler": "^1.12.4",
     "sass": "^1.23.0",
-    "stylelint": "^10.1.0"
+    "stylelint": "10.1.0"
   },
   "scripts": {
     "contrib": "npx parcel contrib/index.html --out-dir contrib/build",


### PR DESCRIPTION
-  Remove ESLint
    - We no longer have any JavaScript to lint in this repo.
- Unify stylelint version, ignore from Dependabot
    - This locks stylelint to specific versions and ignore it from Dependabot so that it doesn't automatically open Pull Requests to update them.
    - The reason is because Hound has a specific version of stylelint that it runs, and so while we might be using v12 of stylelint locally, Hound is running v10 in our Pull Requests and so the results can differ.
    - Hound publishes their [supported linter versions][supported-linters] and we can configure Hound to use specific versions via its `.hound.yml` config.
    - Since these are just development tools, I think its probably fine for them to be updated manually and less frequent than with Dependabot.

[supported-linters]: http://help.houndci.com/en/articles/2461415-supported-linters

