### PR TITLE
Update bundler on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,8 @@ jobs:
   build:
     docker:
       - image: circleci/ruby:2.7.0
+        environment:
+          BUNDLE_PATH: vendor/bundle
 
     steps:
       - checkout
@@ -14,7 +16,7 @@ jobs:
 
       - run:
           name: Install Ruby dependencies
-          command: bundle install --path vendor/bundle
+          command: bundle install
 
       - save_cache:
           key: bitters-{{ arch }}-{{ checksum "bitters.gemspec" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.6.5
+      - image: circleci/ruby:2.7.0
 
     steps:
       - checkout

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 2.6.5
+ruby 2.7.0
 nodejs 10.16.3


### PR DESCRIPTION
- Updates Ruby to 2.7.0.
- Tells Circle CI where to install `bundle` using an environment variable. Using the `--path` flag is deprecated on Circle CI.

Resolves https://github.com/thoughtbot/bitters/issues/382.